### PR TITLE
Altered bundled desktop module to make use of xdg-open instead of desktop-specific tools

### DIFF
--- a/desktop/__init__.py
+++ b/desktop/__init__.py
@@ -257,13 +257,13 @@ def open(url, desktop=None, wait=0):
         return os.startfile(url)
 
     elif desktop_in_use == "KDE":
-        cmd = ["kfmclient", "exec", url]
+        cmd = ["xdg-open", url]
 
     elif desktop_in_use == "GNOME":
-        cmd = ["gnome-open", url]
+        cmd = ["xdg-open", url]
 
     elif desktop_in_use == "XFCE":
-        cmd = ["exo-open", url]
+        cmd = ["xdg-open", url]
 
     elif desktop_in_use == "Mac OS X":
         cmd = ["open", url]


### PR DESCRIPTION
Hi,

tl;dr:
Not much of a change but's been important for me to get Markdown Preview running. Please advise the user to install libgnome2-0 under the latest Debian-based distributions in order to install the gnome-open utility or merge.

In the beginning of time...
on a fresh install of Ubuntu 11.10 I got the following error while trying to preview a file via your plugin:

```
<sublime.Edit object at 0x7fc765516ec0> browser
  Traceback (most recent call last):
  File "./sublime_plugin.py", line 344, in run_
  File "./MarkdownPreview.py", line 47, in run
  File "./desktop/__init__.py", line 279, in open
  File "./desktop/__init__.py", line 86, in _run
  File ".\subprocess.py", line 633, in __init__
  File ".\subprocess.py", line 1139, in _execute_child
OSError: [Errno 2] No such file or directory
```

I don't have much of a python history, but it seems that the desktop module relies on gnome-open which isn't included anymore in Ubuntu's (and other distribution's) initial setup. One may install libgnome2-0, but well, that's like still playing Lego with your 45 year old son because you've been used to do that all these years.

Each desktop environment has its own open utility although there's a generic variant called [xdg-open](http://portland.freedesktop.org/xdg-utils-1.0/xdg-open.html) which seems to be desktop-agnostic. Guess there's still a problem here and there, but from what I've read and tested (on Ubuntu at least) it's the better choice overall.

Best,
Mike
