### PR TITLE
Do a pure md>html conversion when previewing in Sublime

### DIFF
--- a/MarkdownPreview.py
+++ b/MarkdownPreview.py
@@ -112,17 +112,18 @@ class MarkdownPreviewCommand(sublime_plugin.TextCommand):
         # check if LiveReload ST2 extension installed
         livereload_installed = ('LiveReload' in os.listdir(sublime.packages_path()))
 
-        # build the html
-        html_contents = u'<!DOCTYPE html>'
-        html_contents += '<html><head><meta charset="%s">' % encoding
-        html_contents += self.getCSS()
-        if livereload_installed:
-            html_contents += '<script>document.write(\'<script src="http://\' + (location.host || \'localhost\').split(\':\')[0] + \':35729/livereload.js?snipver=1"></\' + \'script>\')</script>'
-        html_contents += '</head><body>'
-        html_contents += markdown_html
-        html_contents += '</body>'
 
         if target in ['disk', 'browser']:
+            # build the html
+            html_contents = u'<!DOCTYPE html>'
+            html_contents += '<html><head><meta charset="%s">' % encoding
+            html_contents += self.getCSS()
+            if livereload_installed:
+                html_contents += '<script>document.write(\'<script src="http://\' + (location.host || \'localhost\').split(\':\')[0] + \':35729/livereload.js?snipver=1"></\' + \'script>\')</script>'
+            html_contents += '</head><body>'
+            html_contents += markdown_html
+            html_contents += '</body>'
+
             # update output html file
             tmp_fullpath = getTempMarkdownPreviewPath(self.view)
             tmp_html = open(tmp_fullpath, 'w')
@@ -145,6 +146,9 @@ class MarkdownPreviewCommand(sublime_plugin.TextCommand):
                     desktop.open(tmp_fullpath)
                     sublime.status_message('Markdown preview launched in default html viewer')
         elif target == 'sublime':
+            # build the html
+            html_contents = markdown_html
+            
             new_view = self.view.window().new_file()
             new_edit = new_view.begin_edit()
             new_view.insert(new_edit, 0, html_contents)


### PR DESCRIPTION
Full HTML preview for disk and browser preview. Pure conversion without extraneous styles and markup when previewing in Sublime.

This is a modification I have been using as I find it really nice to get a styled preview in browser/disk but only want the raw MD conversion to copy out of sublime.
