### PR TITLE
Markdown Preview in Sublime is now a scratch view

### DIFF
--- a/MarkdownPreview.py
+++ b/MarkdownPreview.py
@@ -174,6 +174,7 @@ class MarkdownPreviewCommand(sublime_plugin.TextCommand):
             # build the html
             html_contents = markdown_html
             new_view = self.view.window().new_file()
+						new_view.set_scratch(True)
             new_edit = new_view.begin_edit()
             new_view.insert(new_edit, 0, html_contents)
             new_view.end_edit(new_edit)


### PR DESCRIPTION
When you would preview markdown in Sublime it would open a new view with the output, and when you closed it it would ask if you wanted to save the preview output. 

Setting the view to scratch gets rid of those repetitive  "Do you wanna save? Do you?!.. How about now?" messages. 

This change only adds one line.
