### PR TITLE
Add support for UTF-8 with BOM encoding

### DIFF
--- a/MarkdownPreview.py
+++ b/MarkdownPreview.py
@@ -84,6 +84,8 @@ class MarkdownPreviewCommand(sublime_plugin.TextCommand):
             encoding = 'utf-8'
         elif encoding == 'Western (Windows 1252)':
             encoding = 'windows-1252'
+        elif encoding == 'UTF-8 with BOM':
+            encoding = 'utf-8'
         contents = self.view.substr(region)
 
         config_parser = settings.get('parser')


### PR DESCRIPTION
encode() does not support utf-8 with BOM. Some text editors save in it. This fixes an error when trying to preview markdown files encoded with utf-8.
