### PR TITLE
Allow per-document CSS override files

### DIFF
--- a/MarkdownPreview.py
+++ b/MarkdownPreview.py
@@ -46,8 +46,9 @@ class MarkdownPreviewCommand(sublime_plugin.TextCommand):
         config_parser = settings.get('parser')
         config_css = settings.get('css')
 
+        styles = ''
         if config_css and config_css != 'default':
-            return "<link href='%s' rel='stylesheet' type='text/css'>" % config_css
+            styles += u"<link href='%s' rel='stylesheet' type='text/css'>" % config_css
         else:
             css_filename = 'markdown.css'
             if config_parser and config_parser == 'github':
@@ -60,7 +61,18 @@ class MarkdownPreviewCommand(sublime_plugin.TextCommand):
                 if not os.path.isfile(css_path):
                     sublime.error_message('markdown.css file not found!')
                     raise Exception("markdown.css file not found!")
-            styles = u"<style>%s</style>" % open(css_path, 'r').read().decode('utf-8')
+            styles += u"<style>%s</style>" % open(css_path, 'r').read().decode('utf-8')
+
+        if settings.get('allow_css_overrides'):
+            filename = self.view.file_name()
+            filetypes = settings.get('markdown_filetypes')
+
+            for filetype in filetypes:
+                if filename.endswith(filetype):
+                    css_filename = filename.rpartition(filetype)[0] + '.css'
+                if (os.path.isfile(css_filename)):
+                    styles += u"<style>%s</style>" % open(css_filename, 'r').read().decode('utf-8')
+
         return styles
 
     def postprocessor(self, html):

--- a/MarkdownPreview.sublime-settings
+++ b/MarkdownPreview.sublime-settings
@@ -28,6 +28,14 @@
     "css": "default",
 
     /*
+        Allow CSS overrides
+
+        true - Any file with matching a .markdown_filetype extension with .css will be loaded as an override
+        false - Matching files ignored
+    */
+    "allow_css_overrides": true,
+
+    /*
         Sets the supported filetypes for auto-reload on save
     */
     "markdown_filetypes": [".md", ".markdown", ".mdown"]


### PR DESCRIPTION
Allow the addition of document-specific CSS by creating a CSS file and storing it alongside the Markdown, eg. running conversion on "sample.md" in directory "work_directory" per:

```
work_directory
| sample.md
| sample.css
```

will apply the styles found in sample.css as the last step of loading CSS.

Also:
- Added a setting to disable the feature ("allow_css_overrides") in case of collision
- Reworked the getCSS function slightly so that overrides will also apply with non-default base css configured in settings
