### PR TITLE
Fixes padding in multi-line code blocks

### DIFF
--- a/markdown.css
+++ b/markdown.css
@@ -71,8 +71,8 @@ pre , code, kbd, samp {
   background-color: #F8F8F8;
   border: 1px solid #CCC; 
 }
-pre { white-space: pre; white-space: pre-wrap; word-wrap: break-word; padding: 5px;}
-pre code { border: 0px !important; }
+pre { white-space: pre; white-space: pre-wrap; word-wrap: break-word; padding: 5px 12px;}
+pre code { border: 0px !important; padding: 0;}
 code { padding: 0 3px 0 3px; }
 
 b, strong { font-weight: bold; }


### PR DESCRIPTION
`padding: 5px 12px;` on `pre` makes for balanced horizontal and vertical padding on monospace fonts; `padding: 0;` on `pre code` fixes the first line of a code block being indented by the `code` padding rule while the rest aren't.

![changes](https://f.cloud.github.com/assets/1760908/170680/c584ad90-7a78-11e2-8d12-4e506066df3e.png)
