### PR TITLE
Fix CSS overrides with non-default CSS settings

### DIFF
--- a/MarkdownPreview.py
+++ b/MarkdownPreview.py
@@ -70,8 +70,8 @@ class MarkdownPreviewCommand(sublime_plugin.TextCommand):
             for filetype in filetypes:
                 if filename.endswith(filetype):
                     css_filename = filename.rpartition(filetype)[0] + '.css'
-                if (os.path.isfile(css_filename)):
-                    styles += u"<style>%s</style>" % open(css_filename, 'r').read().decode('utf-8')
+                    if (os.path.isfile(css_filename)):
+                        styles += u"<style>%s</style>" % open(css_filename, 'r').read().decode('utf-8')
 
         return styles
 


### PR DESCRIPTION
Fixes a bug that occurs when there is a non-default `css` setting specified and you try to preview a markdown file with an extension other than the first listed in `markdown_filetypes` setting (e.g. ".markdown" instead of ".md").

In that particular set of circumstances the `css_filename` variable is referenced in the `if (os.path.isfile(css_filename)):` without it ever being assigned.
