### PR TITLE
Fix TOC URLs

### DIFF
--- a/MarkdownPreview.py
+++ b/MarkdownPreview.py
@@ -102,7 +102,7 @@ class MarkdownPreviewCommand(sublime_plugin.TextCommand):
             tag, src = match.groups()
             filename = self.view.file_name()
             if filename:
-                if not src.startswith(('file://', 'https://', 'http://', '/')):
+                if not src.startswith(('file://', 'https://', 'http://', '/', '#')):
                     abs_path = u'file://%s/%s' % (os.path.dirname(filename), src)
                     tag = tag.replace(src, abs_path)
             return tag


### PR DESCRIPTION
The `postprocessor()` method is changing TOC URLs and including `file://` as a prefix. I think it's enough to the TOC links to be just as `"#something"`. So, it looks like there's no need for the whole path prefixing it as in `"file:///home/user/file.html#something"`. It would help everyone who is generating HTML in st2 and then pasting it to some web-based editor.
