### PR TITLE
Fixed mathjax underscore error

### DIFF
--- a/MarkdownPreview.py
+++ b/MarkdownPreview.py
@@ -180,7 +180,10 @@ class MarkdownPreviewCommand(sublime_plugin.TextCommand):
                 sublime.status_message('converted markdown with github API successfully')
         else:
             # convert the markdown
-            markdown_html = markdown2.markdown(markdown, extras=['footnotes', 'toc', 'fenced-code-blocks', 'cuddled-lists'])
+            if settings.get("enable_mathjax") is True or settings.get("enable_highlight") is True:
+                markdown_html = markdown2.markdown(markdown, extras=['footnotes', 'toc', 'fenced-code-blocks', 'cuddled-lists', 'code-friendly'])
+            else:
+                markdown_html = markdown2.markdown(markdown, extras=['footnotes', 'toc', 'fenced-code-blocks', 'cuddled-lists'])
             toc_html = markdown_html.toc_html
             if toc_html:
                 toc_markers = ['[toc]', '[TOC]', '<!--TOC-->']

--- a/mathjax.html
+++ b/mathjax.html
@@ -2,7 +2,7 @@
 <script>
 MathJax.Hub.Config({
   config: ["MMLorHTML.js"],
-  extensions: ["tex2jax.js","TeX/AMSmath.js","TeX/AMSsymbols.js"],
+  extensions: ["tex2jax.js"],
   jax: ["input/TeX"],
   tex2jax: {
     inlineMath: [ ['$','$'], ["\\(","\\)"] ],
@@ -10,6 +10,7 @@ MathJax.Hub.Config({
     processEscapes: false
   },
   TeX: {
+    extensions: ["AMSmath.js", "AMSsymbols.js"],
     TagSide: "right",
     TagIndent: ".8em",
     MultLineWidth: "85%",

--- a/sample.md
+++ b/sample.md
@@ -73,11 +73,17 @@ Also, any indented block is considered a code block.  If `enable_highlight` is `
 
 ## Math
 
-When `enable_mathjax` is `true`, inline math can be included \\(\frac{\pi}{2}\\)
+When `enable_mathjax` is `true`, inline math can be included \\(\frac{\pi}{2}\\) $\pi$
 
 Alternatively, math can be written on it's own line:
 
 $$F(\omega) = \frac{1}{\sqrt{2\pi}} \int_{-\infty}^{\infty} f(t) \, e^{ - i \omega t}dt$$
+
+\\[\int_0^1 f(t) \mathrm{d}t\\]
+
+\\[\sum_j \gamma_j^2/d_j\\]
+
+
 
 ## GitHub Flavored Markdown
 


### PR DESCRIPTION
These changes are in reference to issue [#90](https://github.com/revolunet/sublimetext-markdown-preview/issues/90). The changes add the [code-friendly](https://github.com/revolunet/sublimetext-markdown-preview/issues/90) option to the markdown2 editor when either mathjax or highlight.js is enabled.  This will cause the parser to skip leading, trailing and intra-word underscores, which otherwise are interpreted as `<em>` tags.

I also fixed a mistake in the mathjax config file (mathjax.html) that improperly included extensions necessary for rendering tags such as `\binom`.

Starting a new line with `\\` is still not working properly (still need three backslashes). I'm not sure how to go about fixing that one.
