### PR TITLE
Change capitalization of command captions (ST3)

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -1,27 +1,27 @@
 [
     {
-        "caption": "Markdown Preview: preview in Browser",
+        "caption": "Markdown Preview: Preview in Browser",
         "command": "markdown_preview",
         "args": {
             "target": "browser"
         }
     },
     {
-        "caption": "Markdown Preview: export HTML in Sublime Text",
+        "caption": "Markdown Preview: Export HTML in Sublime Text",
         "command": "markdown_preview",
         "args": {
             "target": "sublime"
         }
     },
     {
-        "caption": "Markdown Preview: copy to clipboard",
+        "caption": "Markdown Preview: Copy to Clipboard",
         "command": "markdown_preview",
         "args": {
             "target": "clipboard"
         }
     },
     {
-        "caption": "Markdown Preview: open Markdown Cheat sheet",
+        "caption": "Markdown Preview: Open Markdown Cheat sheet",
         "command": "markdown_cheatsheet",
         "args": {}
     }


### PR DESCRIPTION
This is the same commit as pull request #108, cherry-picked into the ST3 branch.

For reference, here is that pull request's text:

---

This is a small tweak to rename the Markdown Preview command captions to match the style of other Sublime Text commands. Specifically, it capitalizes the first letter of important words.
