### PR TITLE
Fixed fallback curl github API call

### DIFF
--- a/MarkdownPreview.py
+++ b/MarkdownPreview.py
@@ -284,15 +284,27 @@ class MarkdownCompiler():
     def curl_convert(self, data):
         try:
             import subprocess
-            shell_safe_json = data.decode('utf-8').replace('\"', '\\"').replace("`", "\\`")
+
+            # It looks like the text does NOT need to be escaped and
+            # surrounded with double quotes.
+            # Tested in ubuntu 13.10, python 2.7.5+
+            shell_safe_json = data.decode('utf-8')
             curl_args = [
                 'curl',
                 '-H',
-                '"Content-Type: application/json"',
+                'Content-Type: application/json',
                 '-d',
-                '"' + shell_safe_json + '"',
+                shell_safe_json,
                 'https://api.github.com/markdown'
             ]
+
+            github_oauth_token = self.settings.get('github_oauth_token')
+            if github_oauth_token:
+                curl_args[1:1] = [
+                    '-u',
+                    github_oauth_token
+                ]
+
             markdown_html = subprocess.Popen(curl_args, stdout=subprocess.PIPE).communicate()[0].decode('utf-8')
             return markdown_html
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
The fallback 'curl' method used if ST doesn't include SSL support fails
because of unneeded escape and quotes: escaping the json message text
payload with \" and ` and surrounding it with '"' gives a
'Problems parsing JSON' error from github API.

Special character substitution and double quotes were removed from the
markdown source text sent via subprocess.Popen()

Moreover, the github_oauth_token is used for authentication, when
configured.
