### PR TITLE
Added missing comma in JSON object.

### DIFF
--- a/MarkdownPreview.sublime-settings
+++ b/MarkdownPreview.sublime-settings
@@ -64,7 +64,7 @@
     /*
         Uses an OAuth token to when parsing markdown with GitHub API. To create one for Markdown Preview, see https://help.github.com/articles/creating-an-oauth-token-for-command-line-use.
     */
-    // "github_oauth_token": "secret"
+    // "github_oauth_token": "secret",
 
     /*
         Sets the default css file to embed in the HTML


### PR DESCRIPTION
When the "github_oauth_token" line is uncommented and the file is saved, Sublime Text displays an error message saying that it can’t parse the settings. This is because of the missing comma at the end of the line.
