### PR TITLE
fix #157

### DIFF
--- a/MarkdownPreview.py
+++ b/MarkdownPreview.py
@@ -84,7 +84,7 @@ def load_resource(name):
 
     try:
         if is_ST3():
-            filename = os.path.join('Packages', INSTALLED_DIRECTORY, name)
+            filename = '/'.join(['Packages', INSTALLED_DIRECTORY, name])
             return sublime.load_resource(filename)
         else:
             filename = os.path.join(sublime.packages_path(), INSTALLED_DIRECTORY, name)


### PR DESCRIPTION
According to https://www.sublimetext.com/docs/3/api_reference.html

```
load_resource(name) The name should be in the format Packages/Default/Main.sublime-menu.
```
