### PR TITLE
Support customized html template file

### DIFF
--- a/MarkdownPreview.py
+++ b/MarkdownPreview.py
@@ -390,17 +390,34 @@ class MarkdownCompiler():
         
         body = self.convert_markdown(contents, parser)
 
-        html = u'<!DOCTYPE html>'
-        html += '<html><head><meta charset="utf-8">'
-        html += self.get_stylesheet(parser)
-        html += self.get_javascript()
-        html += self.get_highlight()
-        html += self.get_mathjax()
-        html += self.get_title()
-        html += '</head><body>'
-        html += body
-        html += '</body>'
-        html += '</html>'
+        html_template = self.settings.get('html_template')
+
+        # use customized html template if given
+        if html_template and os.path.exists(html_template):
+            head = u''
+            if not self.settings.get('skip_default_stylesheet'):
+                head += self.get_stylesheet(parser)
+            head += self.get_javascript()
+            head += self.get_highlight()
+            head += self.get_mathjax()
+            head += self.get_title()
+
+            html = load_utf8(html_template)
+            html = html.replace('{{ HEAD }}', head, 1)
+            html = html.replace('{{ BODY }}', body, 1)
+        else:
+            html = u'<!DOCTYPE html>'
+            html += '<html><head><meta charset="utf-8">'
+            html += self.get_stylesheet(parser)
+            html += self.get_javascript()
+            html += self.get_highlight()
+            html += self.get_mathjax()
+            html += self.get_title()
+            html += '</head><body>'
+            html += body
+            html += '</body>'
+            html += '</html>'
+
         return html, body
 
 

--- a/MarkdownPreview.sublime-settings
+++ b/MarkdownPreview.sublime-settings
@@ -83,6 +83,22 @@
     "allow_css_overrides": true,
 
     /*
+        Specify a HTML template file to render your markdown within.
+
+        Available place holders in HTML template:
+        {{ HEAD }} - would be replaced by generated stylesheets, javascripts enabled above
+        {{ BODY }} - would be replaced by HTML converted from markdown
+
+        By setting "skip_default_stylesheet" to true you can use the styles only in your HTML
+        templat. In most case you should turn this setting on to have a full featured design.
+
+        Refer to 'customized-template-sample.html' as a show case.
+    */
+    // "html_template": "/ABS_PATH_TO_A_HTML_FILE",
+    // "skip_default_stylesheet": true,
+
+
+    /*
         Sets the JavaScript files to embed in the HTML
 
         Set an array of URLs or filepaths to JavaScript files. Absolute filepaths will be loaded

--- a/customized-template-sample.html
+++ b/customized-template-sample.html
@@ -1,0 +1,59 @@
+<html>
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf8">
+	{{ HEAD }}
+	<link rel="stylesheet" type="text/css" href="http://netdna.bootstrapcdn.com/bootstrap/3.1.0/css/bootstrap.min.css">
+	<script type="text/javascript" src="http://code.jquery.com/jquery-2.1.0.min.js"></script>
+	<style type="text/css">
+		body {
+			background-color: #EEE;
+			margin: 2em 0;
+			font-size: 12pt;
+			font-family: "Helvetica Neue", "Helvetica", "Arial", "Hiragino Sans GB", sans-serif;
+			line-height: 150%;
+		}
+		blockquote {
+			font-size: inherit;
+		}
+		#container {
+			background-color: #FFF;
+			/*box-shadow: 0px 0px 10px #CCC;*/
+			/*border: 3px solid #DDD;*/
+			padding: 1em 2em;
+			box-shadow: 0 0 0.5em #e6e6e6 inset,0 0 0 1px #d3d3d3;
+			border-radius: 0.5em;
+			margin-bottom: 1em;
+		}
+		h1, h2, h3, h4, h5, h6 {
+			border-bottom: 1px solid #EEE;
+			padding-bottom: 0.25em;
+			font-weight: bold;
+			margin-top: 1em;
+		}
+		img {
+			border: 3px solid #e6e6e6;
+			padding: 1em;
+			box-shadow: 0px 0px 10px #d3d3d3;
+		}
+		@media (-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi) {
+			img { zoom: 0.5; }
+		}
+	</style>
+</head>
+<body>
+	<div id="container" class="container">
+		{{ BODY }}
+	</div>
+	<footer class="container">
+		<p class="text-muted text-center">
+			Markdown Preview Theme designed by <a href="https://twitter.com/hozaka" target="_blank">@hozaka</a>.
+		</p>
+	</footer>
+</body>
+</html>
+
+<script type="text/javascript">
+$(document).ready( function() {
+	$('table').addClass('table table-bordered');
+});
+</script>


### PR DESCRIPTION
I add supports to customized html template to wrap the converted markdown. Sometimes people need a different layout / design for generated html as deliverable document. I think this would help.
