### PR TITLE
Allow for responsive widths

### DIFF
--- a/github.css
+++ b/github.css
@@ -9,7 +9,7 @@ body
     border: 3px solid #EEE;
     box-shadow: inset 0 0 0 1px #CECECE;
     font-family: Helvetica, arial, freesans, clean, sans-serif;
-    width: 912px;
+    max-width: 912px;
     padding: 30px;
     margin: 2em auto;
 


### PR DESCRIPTION
Changing width to max-width will allow the output to be resized on smaller browsers and devices. 

I teach with markdown and I need to bump up the font size quite a bit and this is causing horizontal scrolling. max-width will resize once you get smaller than 912px.

This is also how the marked app works.
