### PR TITLE
updated TOC example

### DIFF
--- a/sample.md
+++ b/sample.md
@@ -12,7 +12,7 @@ this is `important` text. and percentage signs : % and `%`
 
 This is a paragraph with a footnote (builtin parser only). [^note-id]
 
-Insert `[ toc ]` without spaces to generate a table of contents (builtin parsers only).
+Insert `[ TOC ]` without spaces to generate a table of contents (builtin parsers only).
 
 ## Indentation
 > Here is some indented text


### PR DESCRIPTION
The TOC example was lowercase in the example, which does not work with the given instructions. This can be confusing unless you consult the TOC plugin documentation.
