### PR TITLE
In Mac OS, show previews in browser instead of HTML program

### DIFF
--- a/MarkdownPreview.py
+++ b/MarkdownPreview.py
@@ -440,7 +440,7 @@ class MarkdownPreviewCommand(sublime_plugin.TextCommand):
             save_utf8(tmp_fullpath, html)
             # now opens in browser if needed
             if target == 'browser':
-                self.__class__.open_in_browser(tmp_fullpath)
+                self.__class__.open_in_browser(tmp_fullpath, settings.get('browser', 'default'))
         elif target == 'sublime':
             # create a new buffer and paste the output HTML
             embed_css = settings.get('embed_css_for_sublime_output', True)


### PR DESCRIPTION
Thanks for the great package!

In Mac OS `open` with a path to an HTML file will invoke the default program for opening HTML files. For me and many Sublime users, this is Sublime, not Chrome.

This adds code which automatically gets the default browser on Mac OS.

Here's a Stack Overflow question I just posted, on the subject: http://stackoverflow.com/q/23506033/893113
