### PR TITLE
Call MathJax over https

### DIFF
--- a/mathjax.html
+++ b/mathjax.html
@@ -1,4 +1,4 @@
-<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 <script>
 MathJax.Hub.Config({
   config: ["MMLorHTML.js"],


### PR DESCRIPTION
## Call MathJax over https
#### What?

A very simple change: instead of calling MathJax with `http://...`, now is called over `https://...`.
#### Why?

Loading MathJax over `http` triggered security warnings in Chrome and flat-out refused loading in the default behavior in Firefox, unless the user thought about clicking the shield icon next to the address and choosing to allow loading from insecure sources. Let's say that this is less than ideal.
#### Fixed?

Yes, according to my testing at least. A very simple fix that now doesn't trigger any warnings for the end user. Also, extra security afforded by the `https` protocol.
#### Credit

... were credit is due. Thanks to _Julien Bouquillon_ aka [revolunet](https://github.com/revolunet) for the awesome package & to _Brian P. Schmidt_ aka [bps10](https://github.com/bps10) for the package's MathJax support. 
#### See more

[Secure access to MathJax from the CDN](http://docs.mathjax.org/en/latest/start.html#secure-access-to-the-cdn) in MathJax documentation.
