### PR TITLE
Help with Issue #271: Update kbd in github.css to be consistent with GitHub.com

### DIFF
--- a/github.css
+++ b/github.css
@@ -686,17 +686,17 @@ body .markdown-body
 }
 
 .markdown-body kbd {
-  background-color: #e7e7e7;
-  background-image: -webkit-linear-gradient(#fefefe, #e7e7e7);
-  background-image: linear-gradient(#fefefe, #e7e7e7);
-  background-repeat: repeat-x;
   display: inline-block;
   padding: 3px 5px;
-  font: 11px Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  font-size: 11px;
   line-height: 10px;
-  color: #000;
-  border: 1px solid #cfcfcf;
-  border-radius: 2px;
+  color: #555;
+  vertical-align: middle;
+  background-color: #fcfcfc;
+  border: solid 1px #ccc;
+  border-bottom-color: #bbb;
+  border-radius: 3px;
+  box-shadow: inset 0 -1px 0 #bbb;
 }
 
 .markdown-body .highlight .pl-coc,


### PR DESCRIPTION
Fixed it. Tested with Sublime Text 3 build 3065 under OS X 10.10.2.     
Preview:
![2015-03-16 01 45 05](https://cloud.githubusercontent.com/assets/2491781/6657183/3107ca36-cb7e-11e4-9263-b2a0f89a6cde.png)

Reference:
https://github.com/sindresorhus/github-markdown-css/blob/gh-pages/github
-markdown.css