### PR TITLE
support large markdown file size (curl request to github can not be performed using popen)

### DIFF
--- a/MarkdownPreview.py
+++ b/MarkdownPreview.py
@@ -800,20 +800,16 @@ class Compiler(object):
 class GithubCompiler(Compiler):
     default_css = "github.css"
 
-    def curl_convert(self, data):
+    def curl_convert(self, data, fname='/tmp/.sl-gh_md.preview'):
         try:
             import subprocess
 
-            # It looks like the text does NOT need to be escaped and
-            # surrounded with double quotes.
-            # Tested in ubuntu 13.10, python 2.7.5+
-            shell_safe_json = data.decode('utf-8')
             curl_args = [
                 'curl',
                 '-H',
                 'Content-Type: application/json',
                 '-d',
-                shell_safe_json,
+                '@%s' % fname,
                 'https://api.github.com/markdown'
             ]
 
@@ -823,6 +819,9 @@ class GithubCompiler(Compiler):
                     '-u',
                     github_oauth_token
                 ]
+
+            with open(fname, 'w') as tfile:
+                tfile.write(data.decode('utf-8'))
 
             markdown_html = subprocess.Popen(curl_args, stdout=subprocess.PIPE).communicate()[0].decode('utf-8')
             return markdown_html


### PR DESCRIPTION
Context: MarkdownPreview.py: **GithubCompiler**
I'am write (from time to time ;) ) large markdown single page, as soon as markdown file bigger then approximate 60KB, popen can't start curl with big command line.
This simple fix solved problem by using temporary file. Curl must be started with @filename parameter containing markdown text.
