### PR TITLE
Upgrade Markdown

### DIFF
--- a/MarkdownPreview.sublime-settings
+++ b/MarkdownPreview.sublime-settings
@@ -60,8 +60,29 @@
         Pygments support for syntax highlighting.  Controls whether codehilite extension
         will use Pygments.  If disabled, code blocks will be formatted for javascript
         highighters such as highlight.js.
+
+        If you manually set codehilite as an included extension in "enabled_extensions",
+        your settings will override this one.  To configure using pygments manually:
+            "enabled_extensions": [
+                "codehilite(use_pygments=False)" // <-Turn off pygments usage
+            ]
     */
     "enable_pygments": true,
+
+    /*
+        Sets whether highlight JS will auto-guess raw block's syntax.
+        Alternative is to to only highlight blocks where a language has
+        been defined.
+
+        Default is True (guess).
+
+        If you manually set codehilite as an included extension in "enabled_extensions",
+        your settings will override this one.  To configure language guessing manually:
+            "enabled_extensions": [
+                "codehilite(guess_lang=False)" // <-Turn off language guessing
+            ]
+    */
+    "guess_language": true,
 
     /*
         List of enabled extensions of the selected markdown parser.
@@ -73,11 +94,11 @@
         default - use the default set of extensions, see table later.
         [ "default", "def_list", ... ] - a list of extensions. Use "default" to include the default extensions.
 
-         Parser     | "default" Values
+            Parser     | "default" Values
         ------------|---------------------------
-         default    | ["extra", "github", "toc", "headerid", "meta", "sane_lists", "smarty", "wikilinks"]
-         markdown   | ["extra", "github", "toc", "headerid", "meta", "sane_lists", "smarty", "wikilinks"]
-         github     | extension's values are not used.
+            default    | ["extra", "github", "toc", "meta", "sane_lists", "smarty", "wikilinks"]
+            markdown   | ["extra", "github", "toc", "meta", "sane_lists", "smarty", "wikilinks"]
+            github     | extension's values are not used.
 
     */
     "enabled_extensions": "default",
@@ -194,7 +215,7 @@
         Setting is a string value: (absolute | relative | base64 | none)
             absolute: converts relative local paths to absolute
             relative: converts relative local paths to a path relative to the
-                      HTML output
+                        HTML output
             base64: coverts the local file to base64 and embeds it in the HTML
             none: does nothing
     */
@@ -205,7 +226,7 @@
         Setting is a string value: (absolute | relative | none)
             absolute: converts relative local paths to absolute
             relative: converts relative local paths to a path relative to the
-                      HTML output
+                        HTML output
             none: does nothing
     */
     "file_path_conversions": "absolute",
@@ -218,21 +239,6 @@
             none: does nothing
     */
     "strip_critic_marks": "none",
-
-    /*
-        Sets whether highlight JS will auto-guess raw block's syntax.
-        Alternative is to to only highlight blocks where a language has
-        been defined.
-
-        Default is True (guess).
-
-        If you manually set codehilite as an included extension in "enabled_extensions",
-        your settings will override this one.  To configure language guessing manually:
-            "enabled_extensions": [
-                "codehilite(guess_lang=False)" // <-Turn off language guessing
-            ]
-    */
-    "guess_language": true,
 
     /*
         Strips the YAML front matter header and converts title to a heading

--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ You can use builtin [python-markdown][10] parser or use the [github markdown API
 
     | Extension | Documentation |
     |-----------|---------------|
-    | magiclink | Find and convert HTML links and email address to links ([MagicLink Documentation](http://facelessuser.github.io/PyMdown/Extensions/MagicLink.html)). |
+    | magiclink | Find and convert HTML links and email address to links ([MagicLink Documentation](http://facelessuser.github.io/PyMdown/extensions/magiclink/)). |
     | delete | Surround inline text with `~~crossed out~~` to get del tags ~~crossed out~~. |
     | insert | Surround inline text with `^^underlined^^` to get ins tags <ins>underlined</ins>. |
-    | tasklist | Github Flavored Markdown tasklists ([Tasklist Documentation](http://facelessuser.github.io/PyMdown/Extensions/Tasklist.html)). |
-    | githubemoji | Support for Github Flavored Markdown emojis ([GithubEmoji Documentation](http://facelessuser.github.io/PyMdown/Extensions/GithubEmoji.html)). |
-    | headeranchor | Github Flavored Markdown style header anchors ([HeaderAnchor Documentation](http://facelessuser.github.io/PyMdown/Extensions/HeaderAnchor.html)). |
+    | tasklist | Github Flavored Markdown tasklists ([Tasklist Documentation](http://facelessuser.github.io/PyMdown/extensions/tasklist/)). |
+    | githubemoji | Support for Github Flavored Markdown emojis ([GithubEmoji Documentation](http://facelessuser.github.io/PyMdown/extensions/githubemoji/)). |
+    | headeranchor | Github Flavored Markdown style header anchors ([HeaderAnchor Documentation](http://facelessuser.github.io/PyMdown/extensions/headeranchor/)). |
     | github | A convenience extension to add: `magiclink`, `delete`, `tasklist`, `githubemoji`, `headeranchor`, `superfences`, and `nl2br` to parse and display Markdown in a github-ish way.  It is recommed to pair `github` with `extra` and `codehilite` (with language guessing off) to parse close to github's way.  Be aware of what extensions `github` loads, because you should not load extensions more than once. |
-    | progressbar | Create progress bars ([ProgressBar Documentation](http://facelessuser.github.io/PyMdown/Extensions/ProgressBar.html)). |
-    | superfences | Allow fenced blocks to be nested under lists, blockquotes, etc. and add special UML diagram blocks ([SuperFences Documentation](http://facelessuser.github.io/PyMdown/Extensions/SuperFences.html)). |
+    | progressbar | Create progress bars ([ProgressBar Documentation](http://facelessuser.github.io/PyMdown/extensions/progressbar/)). |
+    | superfences | Allow fenced blocks to be nested under lists, blockquotes, etc. and add special UML diagram blocks ([SuperFences Documentation](http://facelessuser.github.io/PyMdown/extensions/superfences/)). |
 
 ## Installation :
 

--- a/markdown/__init__.py
+++ b/markdown/__init__.py
@@ -32,7 +32,7 @@ License: BSD (see LICENSE for details).
 
 from __future__ import absolute_import
 from __future__ import unicode_literals
-from .__version__ import version, version_info
+from .__version__ import version, version_info  # noqa
 import codecs
 import sys
 PY3 = sys.version_info >= (3, 0)
@@ -51,13 +51,8 @@ from .serializers import to_html_string, to_xhtml_string
 
 __all__ = ['Markdown', 'markdown', 'markdownFromFile']
 
-logger = logging.getLogger('MARKDOWN')
 
-try:
-    logging.captureWarnings(True)
-except AttributeError:
-    # Python 2.6 does not contain `captureWarnings`, ignore for now.
-    pass
+logger = logging.getLogger('MARKDOWN')
 
 
 class Markdown(object):
@@ -66,24 +61,24 @@ class Markdown(object):
     doc_tag = "div"     # Element used to wrap document - later removed
 
     option_defaults = {
-        'html_replacement_text' : '[HTML_REMOVED]',
-        'tab_length'            : 4,
-        'enable_attributes'     : True,
-        'smart_emphasis'        : True,
-        'lazy_ol'               : True,
+        'html_replacement_text': '[HTML_REMOVED]',
+        'tab_length':            4,
+        'enable_attributes':     True,
+        'smart_emphasis':        True,
+        'lazy_ol':               True,
     }
 
     output_formats = {
-        'html'  : to_html_string,
-        'html4' : to_html_string,
-        'html5' : to_html_string,
-        'xhtml' : to_xhtml_string,
+        'html':   to_html_string,
+        'html4':  to_html_string,
+        'html5':  to_html_string,
+        'xhtml':  to_xhtml_string,
         'xhtml1': to_xhtml_string,
         'xhtml5': to_xhtml_string,
     }
 
     ESCAPED_CHARS = ['\\', '`', '*', '_', '{', '}', '[', ']',
-                    '(', ')', '>', '#', '+', '-', '.', '!']
+                     '(', ')', '>', '#', '+', '-', '.', '!']
 
     def __init__(self, *args, **kwargs):
         """
@@ -95,19 +90,23 @@ class Markdown(object):
            If they are of type string, the module mdx_name.py will be loaded.
            If they are a subclass of markdown.Extension, they will be used
            as-is.
-        * extension_configs: Configuration settingis for extensions.
+        * extension_configs: Configuration settings for extensions.
         * output_format: Format of output. Supported formats are:
             * "xhtml1": Outputs XHTML 1.x. Default.
             * "xhtml5": Outputs XHTML style tags of HTML 5
-            * "xhtml": Outputs latest supported version of XHTML (currently XHTML 1.1).
+            * "xhtml": Outputs latest supported version of XHTML
+              (currently XHTML 1.1).
             * "html4": Outputs HTML 4
             * "html5": Outputs HTML style tags of HTML 5
-            * "html": Outputs latest supported version of HTML (currently HTML 4).
+            * "html": Outputs latest supported version of HTML
+              (currently HTML 4).
             Note that it is suggested that the more specific formats ("xhtml1"
             and "html4") be used as "xhtml" or "html" may change in the future
             if it makes sense at that time.
-        * safe_mode: Deprecated! Disallow raw html. One of "remove", "replace" or "escape".
-        * html_replacement_text: Deprecated! Text used when safe_mode is set to "replace".
+        * safe_mode: Deprecated! Disallow raw html. One of "remove", "replace"
+          or "escape".
+        * html_replacement_text: Deprecated! Text used when safe_mode is set
+          to "replace".
         * tab_length: Length of tabs in the source. Default: 4
         * enable_attributes: Enable the conversion of attributes. Default: True
         * smart_emphasis: Treat `_connected_words_` intelligently Default: True
@@ -120,13 +119,13 @@ class Markdown(object):
         for c, arg in enumerate(args):
             if pos[c] not in kwargs:
                 kwargs[pos[c]] = arg
-            if c+1 == len(pos): #pragma: no cover
+            if c+1 == len(pos):  # pragma: no cover
                 # ignore any additional args
                 break
         if len(args):
-            warnings.warn('Positional arguments are pending depreacted in Markdown '
-                          'and will be deprecated in version 2.6. Use keyword '
-                          'arguments only.', PendingDeprecationWarning)
+            warnings.warn('Positional arguments are deprecated in Markdown. '
+                          'Use keyword arguments only.',
+                          DeprecationWarning)
 
         # Loop through kwargs and assign defaults
         for option, default in self.option_defaults.items():
@@ -138,16 +137,17 @@ class Markdown(object):
             self.enable_attributes = False
 
         if 'safe_mode' in kwargs:
-            warnings.warn('"safe_mode" is pending deprecation in Python-Markdown '
-                          'and will be deprecated in version 2.6. Use an HTML '
-                          'sanitizer (like Bleach http://bleach.readthedocs.org/) '
-                          'if you are parsing untrusted markdown text. See the '
-                          '2.5 release notes for more info', PendingDeprecationWarning)
+            warnings.warn('"safe_mode" is deprecated in Python-Markdown. '
+                          'Use an HTML sanitizer (like '
+                          'Bleach http://bleach.readthedocs.org/) '
+                          'if you are parsing untrusted markdown text. '
+                          'See the 2.6 release notes for more info',
+                          DeprecationWarning)
 
         if 'html_replacement_text' in kwargs:
-            warnings.warn('The "html_replacement_text" keyword is pending deprecation '
-                          'in Python-Markdown and will be deprecated in version 2.6 '
-                          'along with "safe_mode".', PendingDeprecationWarning)
+            warnings.warn('The "html_replacement_text" keyword is '
+                          'deprecated along with "safe_mode".',
+                          DeprecationWarning)
 
         self.registeredExtensions = []
         self.docType = ""
@@ -187,7 +187,7 @@ class Markdown(object):
                 ext = self.build_extension(ext, configs.get(ext, {}))
             if isinstance(ext, Extension):
                 ext.extendMarkdown(self, globals())
-                logger.debug('Successfully loaded extension "%s.%s".' 
+                logger.info('Successfully loaded extension "%s.%s".'
                             % (ext.__class__.__module__, ext.__class__.__name__))
             elif ext is not None:
                 raise TypeError(
@@ -203,37 +203,44 @@ class Markdown(object):
         following format: "extname(key1=value1,key2=value2)"
 
         """
-        
+
         configs = dict(configs)
-        
+
         # Parse extensions config params (ignore the order)
-        pos = ext_name.find("(") # find the first "("
+        pos = ext_name.find("(")  # find the first "("
         if pos > 0:
             ext_args = ext_name[pos+1:-1]
             ext_name = ext_name[:pos]
             pairs = [x.split("=") for x in ext_args.split(",")]
             configs.update([(x.strip(), y.strip()) for (x, y) in pairs])
-            warnings.warn('Setting configs in the Named Extension string is pending deprecation. '
-                          'It is recommended that you pass an instance of the extension class to '
-                          'Markdown or use the "extension_configs" keyword. The current behavior '
-                          'will be deprecated in version 2.6 and raise an error in version 2.7. '
-                          'See the Release Notes for Python-Markdown version 2.5 for more info.', 
-                          PendingDeprecationWarning)
+            warnings.warn('Setting configs in the Named Extension string is '
+                          'deprecated. It is recommended that you '
+                          'pass an instance of the extension class to '
+                          'Markdown or use the "extension_configs" keyword. '
+                          'The current behavior will raise an error in version 2.7. '
+                          'See the Release Notes for Python-Markdown version '
+                          '2.6 for more info.', DeprecationWarning)
 
         # Get class name (if provided): `path.to.module:ClassName`
-        ext_name, class_name = ext_name.split(':', 1) if ':' in ext_name else (ext_name, '')
+        ext_name, class_name = ext_name.split(':', 1) \
+            if ':' in ext_name else (ext_name, '')
 
         # Try loading the extension first from one place, then another
-        try: 
+        try:
             # Assume string uses dot syntax (`path.to.some.module`)
             if PY3:
                 module = importlib.import_module(ext_name)
             else:
                 module = __import__(module_name, {}, {}, [module_name.rpartition('.')[0]])
-            logger.debug('Successfuly imported extension module "%s".' % ext_name)
-            # For backward compat (until deprecation) check that this is an extension
-            if '.' not in ext_name and not (hasattr(module, 'extendMarkdown') or (class_name and hasattr(module, class_name))):
-                # We have a name conflict (eg: extensions=['tables'] and PyTables is installed)
+            logger.debug(
+                'Successfuly imported extension module "%s".' % ext_name
+            )
+            # For backward compat (until deprecation)
+            # check that this is an extension.
+            if ('.' not in ext_name and not (hasattr(module, 'makeExtension') or
+               (class_name and hasattr(module, class_name)))):
+                # We have a name conflict
+                # eg: extensions=['tables'] and PyTables is installed
                 raise ImportError
         except ImportError:
             # Preppend `markdown.extensions.` to name
@@ -243,13 +250,19 @@ class Markdown(object):
                     module = importlib.import_module(module_name)
                 else:
                     module = __import__(module_name, {}, {}, [module_name.rpartition('.')[0]])
-                logger.debug('Successfuly imported extension module "%s".' % module_name)
-                warnings.warn('Using short names for Markdown\'s builtin extensions is pending deprecation. '
-                              'Use the full path to the extension with Python\'s dot notation '
-                              '(eg: "%s" instead of "%s"). The current behavior will be deprecated in '
-                              'version 2.6 and raise an error in version 2.7. See the Release Notes for '
-                              'Python-Markdown version 2.5 for more info.' % (module_name, ext_name), 
-                              PendingDeprecationWarning) 
+                logger.debug(
+                    'Successfuly imported extension module "%s".' %
+                    module_name
+                )
+                warnings.warn('Using short names for Markdown\'s builtin '
+                              'extensions is deprecated. Use the '
+                              'full path to the extension with Python\'s dot '
+                              'notation (eg: "%s" instead of "%s"). The '
+                              'current behavior will raise an error in version '
+                              '2.7. See the Release Notes for '
+                              'Python-Markdown version 2.6 for more info.' %
+                              (module_name, ext_name),
+                              DeprecationWarning)
             except ImportError:
                 # Preppend `mdx_` to name
                 module_name_old_style = '_'.join(['mdx', ext_name])
@@ -258,17 +271,23 @@ class Markdown(object):
                         module = importlib.import_module(module_name_old_style)
                     else:
                         module = __import__(module_name, {}, {}, [module_name.rpartition('.')[0]])
-                    logger.debug('Successfuly imported extension module "%s".' % module_name_old_style)
-                    warnings.warn('Markdown\'s behavuor of appending "mdx_" to an extension name '
-                                  'is pending deprecation. Use the full path to the extension with '
-                                  'Python\'s dot notation (eg: "%s" instead of "%s"). The '
-                                  'current behavior will be deprecated in version 2.6 and raise an '
-                                  'error in version 2.7. See the Release Notes for Python-Markdown '
-                                  'version 2.5 for more info.' % (module_name_old_style, ext_name),
-                                  PendingDeprecationWarning) 
+                    logger.debug(
+                        'Successfuly imported extension module "%s".' %
+                        module_name_old_style)
+                    warnings.warn('Markdown\'s behavior of prepending "mdx_" '
+                                  'to an extension name is deprecated. '
+                                  'Use the full path to the '
+                                  'extension with Python\'s dot notation '
+                                  '(eg: "%s" instead of "%s"). The current '
+                                  'behavior will raise an error in version 2.7. '
+                                  'See the Release Notes for Python-Markdown '
+                                  'version 2.6 for more info.' %
+                                  (module_name_old_style, ext_name),
+                                  DeprecationWarning)
                 except ImportError as e:
-                    message = "Failed loading extension '%s' from '%s', '%s' or '%s'" \
-                        % (ext_name, ext_name, module_name, module_name_old_style)
+                    message = "Failed loading extension '%s' from '%s', '%s' " \
+                        "or '%s'" % (ext_name, ext_name, module_name,
+                                     module_name_old_style)
                     e.args = (message,) + e.args[1:]
                     raise
 
@@ -313,8 +332,8 @@ class Markdown(object):
             valid_formats = list(self.output_formats.keys())
             valid_formats.sort()
             message = 'Invalid Output Format: "%s". Use one of %s.' \
-                       % (self.output_format, 
-                          '"' + '", "'.join(valid_formats) + '"')
+                % (self.output_format,
+                   '"' + '", "'.join(valid_formats) + '"')
             e.args = (message,) + e.args[1:]
             raise
         return self
@@ -370,16 +389,18 @@ class Markdown(object):
         output = self.serializer(root)
         if self.stripTopLevelTags:
             try:
-                start = output.index('<%s>'%self.doc_tag)+len(self.doc_tag)+2
-                end = output.rindex('</%s>'%self.doc_tag)
+                start = output.index(
+                    '<%s>' % self.doc_tag) + len(self.doc_tag) + 2
+                end = output.rindex('</%s>' % self.doc_tag)
                 output = output[start:end].strip()
-            except ValueError: #pragma: no cover
-                if output.strip().endswith('<%s />'%self.doc_tag):
+            except ValueError:  # pragma: no cover
+                if output.strip().endswith('<%s />' % self.doc_tag):
                     # We have an empty document
                     output = ''
                 else:
                     # We have a serious problem
-                    raise ValueError('Markdown failed to strip top-level tags. Document=%r' % output.strip())
+                    raise ValueError('Markdown failed to strip top-level '
+                                     'tags. Document=%r' % output.strip())
 
         # Run the text post-processors
         for pp in self.postprocessors.values():
@@ -388,7 +409,7 @@ class Markdown(object):
         return output.strip()
 
     def convertFile(self, input=None, output=None, encoding=None):
-        """Converts a markdown file and returns the HTML as a unicode string.
+        """Converts a Markdown file and returns the HTML as a Unicode string.
 
         Decodes the file using the provided encoding (defaults to utf-8),
         passes the file content to markdown, and outputs the html to either
@@ -396,9 +417,9 @@ class Markdown(object):
         encoding as the source file. The 'xmlcharrefreplace' error handler is
         used when encoding the output.
 
-        **Note:** This is the only place that decoding and encoding of unicode
-        takes place in Python-Markdown.  (All other code is unicode-in /
-        unicode-out.)
+        **Note:** This is the only place that decoding and encoding of Unicode
+        takes place in Python-Markdown.  (All other code is Unicode-in /
+        Unicode-out.)
 
         Keyword arguments:
 
@@ -423,7 +444,7 @@ class Markdown(object):
             if not isinstance(text, util.text_type):
                 text = text.decode(encoding)
 
-        text = text.lstrip('\ufeff') # remove the byte-order mark
+        text = text.lstrip('\ufeff')  # remove the byte-order mark
 
         # Convert
         html = self.convert(text)
@@ -442,7 +463,7 @@ class Markdown(object):
                 output_file.write(html)
                 # Don't close here. User may want to write more.
         else:
-            # Encode manually and write bytes to stdout. 
+            # Encode manually and write bytes to stdout.
             html = html.encode(encoding, "xmlcharrefreplace")
             try:
                 # Write bytes directly to buffer (Python 3).
@@ -462,8 +483,9 @@ Those are the two functions we really mean to export: markdown() and
 markdownFromFile().
 """
 
+
 def markdown(text, *args, **kwargs):
-    """Convert a markdown string to HTML and return HTML as a unicode string.
+    """Convert a Markdown string to HTML and return HTML as a Unicode string.
 
     This is a shortcut function for `Markdown` class to cover the most
     basic use case.  It initializes an instance of Markdown, loads the
@@ -505,9 +527,10 @@ def markdownFromFile(*args, **kwargs):
         if c == len(pos):
             break
     if len(args):
-        warnings.warn('Positional arguments are pending depreacted in Markdown '
-                      'and will be deprecated in version 2.6. Use keyword '
-                      'arguments only.', PendingDeprecationWarning)
+        warnings.warn('Positional arguments are depreacted in '
+                      'Markdown and will raise an error in version 2.7. '
+                      'Use keyword arguments only.',
+                      DeprecationWarning)
 
     md = Markdown(**kwargs)
     md.convertFile(kwargs.get('input', None),

--- a/markdown/__main__.py
+++ b/markdown/__main__.py
@@ -4,19 +4,21 @@ COMMAND-LINE SPECIFIC STUFF
 
 """
 
-import markdown
 import sys
 import optparse
 import codecs
-try: 
+import warnings
+import markdown
+try:
     import yaml
-except ImportError: #pragma: no cover
+except ImportError:  # pragma: no cover
     import json as yaml
 
 import logging
-from logging import DEBUG, INFO, CRITICAL
+from logging import DEBUG, WARNING, CRITICAL
 
-logger =  logging.getLogger('MARKDOWN')
+logger = logging.getLogger('MARKDOWN')
+
 
 def parse_options(args=None, values=None):
     """
@@ -27,7 +29,7 @@ def parse_options(args=None, values=None):
     desc = "A Python implementation of John Gruber's Markdown. " \
            "https://pythonhosted.org/Markdown/"
     ver = "%%prog %s" % markdown.version
-    
+
     parser = optparse.OptionParser(usage=usage, description=desc, version=ver)
     parser.add_option("-f", "--file", dest="filename", default=None,
                       help="Write output to OUTPUT_FILE. Defaults to STDOUT.",
@@ -36,28 +38,32 @@ def parse_options(args=None, values=None):
                       help="Encoding for input and output files.",)
     parser.add_option("-s", "--safe", dest="safe", default=False,
                       metavar="SAFE_MODE",
-                      help="Deprecated! 'replace', 'remove' or 'escape' HTML tags in input")
-    parser.add_option("-o", "--output_format", dest="output_format", 
+                      help="Deprecated! 'replace', 'remove' or 'escape' HTML "
+                      "tags in input")
+    parser.add_option("-o", "--output_format", dest="output_format",
                       default='xhtml1', metavar="OUTPUT_FORMAT",
                       help="'xhtml1' (default), 'html4' or 'html5'.")
-    parser.add_option("-n", "--no_lazy_ol", dest="lazy_ol", 
+    parser.add_option("-n", "--no_lazy_ol", dest="lazy_ol",
                       action='store_false', default=True,
                       help="Observe number of first item of ordered lists.")
     parser.add_option("-x", "--extension", action="append", dest="extensions",
-                      help = "Load extension EXTENSION.", metavar="EXTENSION")
-    parser.add_option("-c", "--extension_configs", dest="configfile", default=None,
+                      help="Load extension EXTENSION.", metavar="EXTENSION")
+    parser.add_option("-c", "--extension_configs",
+                      dest="configfile", default=None,
                       help="Read extension configurations from CONFIG_FILE. "
-                      "CONFIG_FILE must be of JSON or YAML format. YAML format requires "
-                      "that a python YAML library be installed. The parsed JSON or YAML "
-                      "must result in a python dictionary which would be accepted by the "
-                      "'extension_configs' keyword on the markdown.Markdown class. "
-                      "The extensions must also be loaded with the `--extension` option.",
+                      "CONFIG_FILE must be of JSON or YAML format. YAML"
+                      "format requires that a python YAML library be "
+                      "installed. The parsed JSON or YAML must result in a "
+                      "python dictionary which would be accepted by the "
+                      "'extension_configs' keyword on the markdown.Markdown "
+                      "class. The extensions must also be loaded with the "
+                      "`--extension` option.",
                       metavar="CONFIG_FILE")
-    parser.add_option("-q", "--quiet", default = CRITICAL,
+    parser.add_option("-q", "--quiet", default=CRITICAL,
                       action="store_const", const=CRITICAL+10, dest="verbose",
                       help="Suppress all warnings.")
     parser.add_option("-v", "--verbose",
-                      action="store_const", const=INFO, dest="verbose",
+                      action="store_const", const=WARNING, dest="verbose",
                       help="Print all warnings.")
     parser.add_option("--noisy",
                       action="store_const", const=DEBUG, dest="verbose",
@@ -75,37 +81,56 @@ def parse_options(args=None, values=None):
 
     extension_configs = {}
     if options.configfile:
-        with codecs.open(options.configfile, mode="r", encoding=options.encoding) as fp:
+        with codecs.open(
+            options.configfile, mode="r", encoding=options.encoding
+        ) as fp:
             try:
                 extension_configs = yaml.load(fp)
             except Exception as e:
-                message = "Failed parsing extension config file: %s" % options.configfile
+                message = "Failed parsing extension config file: %s" % \
+                          options.configfile
                 e.args = (message,) + e.args[1:]
                 raise
 
-    return {'input': input_file,
-            'output': options.filename,
-            'safe_mode': options.safe,
-            'extensions': options.extensions,
-            'extension_configs': extension_configs,
-            'encoding': options.encoding,
-            'output_format': options.output_format,
-            'lazy_ol': options.lazy_ol}, options.verbose
+    opts = {
+        'input': input_file,
+        'output': options.filename,
+        'extensions': options.extensions,
+        'extension_configs': extension_configs,
+        'encoding': options.encoding,
+        'output_format': options.output_format,
+        'lazy_ol': options.lazy_ol
+    }
 
-def run(): #pragma: no cover
+    if options.safe:
+        # Avoid deprecation warning if user didn't set option
+        opts['safe_mode'] = options.safe
+
+    return opts, options.verbose
+
+
+def run():  # pragma: no cover
     """Run Markdown from the command line."""
 
     # Parse options and adjust logging level if necessary
     options, logging_level = parse_options()
-    if not options: sys.exit(2)
+    if not options:
+        sys.exit(2)
     logger.setLevel(logging_level)
-    logger.addHandler(logging.StreamHandler())
+    console_handler = logging.StreamHandler()
+    logger.addHandler(console_handler)
+    if logging_level <= WARNING:
+        # Ensure deprecation warnings get displayed
+        warnings.filterwarnings('default')
+        logging.captureWarnings(True)
+        warn_logger = logging.getLogger('py.warnings')
+        warn_logger.addHandler(console_handler)
 
     # Run
     markdown.markdownFromFile(**options)
 
-if __name__ == '__main__': #pragma: no cover
-    # Support running module as a commandline command. 
-    # Python 2.5 & 2.6 do: `python -m markdown.__main__ [options] [args]`.
+
+if __name__ == '__main__':  # pragma: no cover
+    # Support running module as a commandline command.
     # Python 2.7 & 3.x do: `python -m markdown [options] [args]`.
     run()

--- a/markdown/__version__.py
+++ b/markdown/__version__.py
@@ -1,11 +1,12 @@
 #
 # markdown/__version__.py
 #
-# version_info should conform to PEP 386 
+# version_info should conform to PEP 386
 # (major, minor, micro, alpha/beta/rc/final, #)
 # (1, 1, 2, 'alpha', 0) => "1.1.2.dev"
 # (1, 2, 0, 'beta', 2) => "1.2b2"
-version_info = (2, 5, 2, 'final', 0)
+version_info = (2, 6, 2, 'final', 0)
+
 
 def _get_version():
     " Returns a PEP 386-compliant version number from version_info. "

--- a/markdown/blockparser.py
+++ b/markdown/blockparser.py
@@ -3,16 +3,17 @@ from __future__ import absolute_import
 from . import util
 from . import odict
 
+
 class State(list):
-    """ Track the current and nested state of the parser. 
-    
-    This utility class is used to track the state of the BlockParser and 
+    """ Track the current and nested state of the parser.
+
+    This utility class is used to track the state of the BlockParser and
     support multiple levels if nesting. It's just a simple API wrapped around
     a list. Each time a state is set, that state is appended to the end of the
     list. Each time a state is reset, that state is removed from the end of
     the list.
 
-    Therefore, each time a state is set for a nested block, that state must be 
+    Therefore, each time a state is set for a nested block, that state must be
     reset when we back out of that level of nesting or the state could be
     corrupted.
 
@@ -36,9 +37,10 @@ class State(list):
         else:
             return False
 
+
 class BlockParser:
-    """ Parse Markdown blocks into an ElementTree object. 
-    
+    """ Parse Markdown blocks into an ElementTree object.
+
     A wrapper class that stitches the various BlockProcessors together,
     looping through them and creating an ElementTree object.
     """
@@ -49,12 +51,12 @@ class BlockParser:
         self.markdown = markdown
 
     def parseDocument(self, lines):
-        """ Parse a markdown document into an ElementTree. 
-        
-        Given a list of lines, an ElementTree object (not just a parent Element)
-        is created and the root element is passed to the parser as the parent.
-        The ElementTree object is returned.
-        
+        """ Parse a markdown document into an ElementTree.
+
+        Given a list of lines, an ElementTree object (not just a parent
+        Element) is created and the root element is passed to the parser
+        as the parent. The ElementTree object is returned.
+
         This should only be called on an entire document, not pieces.
 
         """
@@ -64,29 +66,30 @@ class BlockParser:
         return util.etree.ElementTree(self.root)
 
     def parseChunk(self, parent, text):
-        """ Parse a chunk of markdown text and attach to given etree node. 
-        
+        """ Parse a chunk of markdown text and attach to given etree node.
+
         While the ``text`` argument is generally assumed to contain multiple
         blocks which will be split on blank lines, it could contain only one
         block. Generally, this method would be called by extensions when
-        block parsing is required. 
-        
-        The ``parent`` etree Element passed in is altered in place. 
+        block parsing is required.
+
+        The ``parent`` etree Element passed in is altered in place.
         Nothing is returned.
 
         """
         self.parseBlocks(parent, text.split('\n\n'))
 
     def parseBlocks(self, parent, blocks):
-        """ Process blocks of markdown text and attach to given etree node. 
-        
+        """ Process blocks of markdown text and attach to given etree node.
+
         Given a list of ``blocks``, each blockprocessor is stepped through
         until there are no blocks left. While an extension could potentially
-        call this method directly, it's generally expected to be used internally.
+        call this method directly, it's generally expected to be used
+        internally.
 
-        This is a public method as an extension may need to add/alter additional
-        BlockProcessors which call this method to recursively parse a nested
-        block.
+        This is a public method as an extension may need to add/alter
+        additional BlockProcessors which call this method to recursively
+        parse a nested block.
 
         """
         while blocks:
@@ -95,5 +98,3 @@ class BlockParser:
                     if processor.run(parent, blocks) is not False:
                         # run returns True or None
                         break
-
-

--- a/markdown/blockprocessors.py
+++ b/markdown/blockprocessors.py
@@ -2,9 +2,9 @@
 CORE MARKDOWN BLOCKPARSER
 ===========================================================================
 
-This parser handles basic parsing of Markdown blocks.  It doesn't concern itself
-with inline elements such as **bold** or *italics*, but rather just catches
-blocks, lists, quotes, etc.
+This parser handles basic parsing of Markdown blocks.  It doesn't concern
+itself with inline elements such as **bold** or *italics*, but rather just
+catches blocks, lists, quotes, etc.
 
 The BlockParser is made up of a bunch of BlockProssors, each handling a
 different type of block. Extensions may add/replace/remove BlockProcessors
@@ -19,7 +19,7 @@ import re
 from . import util
 from .blockparser import BlockParser
 
-logger =  logging.getLogger('MARKDOWN')
+logger = logging.getLogger('MARKDOWN')
 
 
 def build_block_parser(md_instance, **kwargs):
@@ -39,8 +39,8 @@ def build_block_parser(md_instance, **kwargs):
 
 
 class BlockProcessor:
-    """ Base class for block processors. 
-    
+    """ Base class for block processors.
+
     Each subclass will provide the methods below to work with the source and
     tree. Each processor will need to define it's own ``test`` and ``run``
     methods. The ``test`` method should return True or False, to indicate
@@ -82,32 +82,32 @@ class BlockProcessor:
         return '\n'.join(lines)
 
     def test(self, parent, block):
-        """ Test for block type. Must be overridden by subclasses. 
-        
-        As the parser loops through processors, it will call the ``test`` method
-        on each to determine if the given block of text is of that type. This
-        method must return a boolean ``True`` or ``False``. The actual method of
-        testing is left to the needs of that particular block type. It could 
-        be as simple as ``block.startswith(some_string)`` or a complex regular
-        expression. As the block type may be different depending on the parent
-        of the block (i.e. inside a list), the parent etree element is also 
-        provided and may be used as part of the test.
+        """ Test for block type. Must be overridden by subclasses.
+
+        As the parser loops through processors, it will call the ``test``
+        method on each to determine if the given block of text is of that
+        type. This method must return a boolean ``True`` or ``False``. The
+        actual method of testing is left to the needs of that particular
+        block type. It could be as simple as ``block.startswith(some_string)``
+        or a complex regular expression. As the block type may be different
+        depending on the parent of the block (i.e. inside a list), the parent
+        etree element is also provided and may be used as part of the test.
 
         Keywords:
-        
+
         * ``parent``: A etree element which will be the parent of the block.
-        * ``block``: A block of text from the source which has been split at 
+        * ``block``: A block of text from the source which has been split at
             blank lines.
         """
-        pass #pragma: no cover
+        pass  # pragma: no cover
 
     def run(self, parent, blocks):
-        """ Run processor. Must be overridden by subclasses. 
-        
+        """ Run processor. Must be overridden by subclasses.
+
         When the parser determines the appropriate type of a block, the parser
         will call the corresponding processor's ``run`` method. This method
         should parse the individual lines of the block and append them to
-        the etree. 
+        the etree.
 
         Note that both the ``parent`` and ``etree`` keywords are pointers
         to instances of the objects which should be edited in place. Each
@@ -123,12 +123,12 @@ class BlockProcessor:
         * ``parent``: A etree element which is the parent of the current block.
         * ``blocks``: A list of all remaining blocks of the document.
         """
-        pass #pragma: no cover
+        pass  # pragma: no cover
 
 
 class ListIndentProcessor(BlockProcessor):
-    """ Process children of list items. 
-    
+    """ Process children of list items.
+
     Example:
         * a list item
             process this part
@@ -142,16 +142,14 @@ class ListIndentProcessor(BlockProcessor):
 
     def __init__(self, *args):
         BlockProcessor.__init__(self, *args)
-        self.INDENT_RE = re.compile(r'^(([ ]{%s})+)'% self.tab_length)
+        self.INDENT_RE = re.compile(r'^(([ ]{%s})+)' % self.tab_length)
 
     def test(self, parent, block):
         return block.startswith(' '*self.tab_length) and \
-                not self.parser.state.isstate('detabbed') and  \
-                (parent.tag in self.ITEM_TYPES or \
-                    (len(parent) and parent[-1] and \
-                        (parent[-1].tag in self.LIST_TYPES)
-                    )
-                )
+            not self.parser.state.isstate('detabbed') and \
+            (parent.tag in self.ITEM_TYPES or
+                (len(parent) and parent[-1] is not None and
+                    (parent[-1].tag in self.LIST_TYPES)))
 
     def run(self, parent, blocks):
         block = blocks.pop(0)
@@ -162,7 +160,7 @@ class ListIndentProcessor(BlockProcessor):
         if parent.tag in self.ITEM_TYPES:
             # It's possible that this parent has a 'ul' or 'ol' child list
             # with a member.  If that is the case, then that should be the
-            # parent.  This is intended to catch the edge case of an indented 
+            # parent.  This is intended to catch the edge case of an indented
             # list whose first member was parsed previous to this point
             # see OListProcessor
             if len(parent) and parent[-1].tag in self.LIST_TYPES:
@@ -193,7 +191,7 @@ class ListIndentProcessor(BlockProcessor):
         """ Create a new li and parse the block with it as the parent. """
         li = util.etree.SubElement(parent, 'li')
         self.parser.parseBlocks(li, [block])
- 
+
     def get_level(self, parent, block):
         """ Get level of indent based on list level. """
         # Get indent level
@@ -211,7 +209,8 @@ class ListIndentProcessor(BlockProcessor):
         # Step through children of tree to find matching indent level.
         while indent_level > level:
             child = self.lastChild(parent)
-            if child is not None and (child.tag in self.LIST_TYPES or child.tag in self.ITEM_TYPES):
+            if (child is not None and
+               (child.tag in self.LIST_TYPES or child.tag in self.ITEM_TYPES)):
                 if child.tag in self.LIST_TYPES:
                     level += 1
                 parent = child
@@ -227,19 +226,21 @@ class CodeBlockProcessor(BlockProcessor):
 
     def test(self, parent, block):
         return block.startswith(' '*self.tab_length)
-    
+
     def run(self, parent, blocks):
         sibling = self.lastChild(parent)
         block = blocks.pop(0)
         theRest = ''
-        if sibling is not None and sibling.tag == "pre" and len(sibling) \
-                    and sibling[0].tag == "code":
+        if (sibling is not None and sibling.tag == "pre" and
+           len(sibling) and sibling[0].tag == "code"):
             # The previous block was a code block. As blank lines do not start
             # new code blocks, append this block to the previous, adding back
             # linebreaks removed from the split into a list.
             code = sibling[0]
             block, theRest = self.detab(block)
-            code.text = util.AtomicString('%s\n%s\n' % (code.text, block.rstrip()))
+            code.text = util.AtomicString(
+                '%s\n%s\n' % (code.text, block.rstrip())
+            )
         else:
             # This is a new codeblock. Create the elements and insert text.
             pre = util.etree.SubElement(parent, 'pre')
@@ -247,7 +248,7 @@ class CodeBlockProcessor(BlockProcessor):
             block, theRest = self.detab(block)
             code.text = util.AtomicString('%s\n' % block.rstrip())
         if theRest:
-            # This block contained unindented line(s) after the first indented 
+            # This block contained unindented line(s) after the first indented
             # line. Insert these lines as the first block of the master blocks
             # list for future processing.
             blocks.insert(0, theRest)
@@ -264,12 +265,13 @@ class BlockQuoteProcessor(BlockProcessor):
         block = blocks.pop(0)
         m = self.RE.search(block)
         if m:
-            before = block[:m.start()] # Lines before blockquote
+            before = block[:m.start()]  # Lines before blockquote
             # Pass lines before blockquote in recursively for parsing forst.
             self.parser.parseBlocks(parent, [before])
             # Remove ``> `` from begining of each line.
-            block = '\n'.join([self.clean(line) for line in 
-                            block[m.start():].split('\n')])
+            block = '\n'.join(
+                [self.clean(line) for line in block[m.start():].split('\n')]
+            )
         sibling = self.lastChild(parent)
         if sibling is not None and sibling.tag == "blockquote":
             # Previous block was a blockquote so set that as this blocks parent
@@ -293,6 +295,7 @@ class BlockQuoteProcessor(BlockProcessor):
         else:
             return line
 
+
 class OListProcessor(BlockProcessor):
     """ Process ordered list blocks. """
 
@@ -308,7 +311,7 @@ class OListProcessor(BlockProcessor):
     #   3. Item
     # The ol tag will get starts="3" attribute
     STARTSWITH = '1'
-    # List of allowed sibling tags. 
+    # List of allowed sibling tags.
     SIBLING_TAGS = ['ol', 'ul']
 
     def test(self, parent, block):
@@ -322,12 +325,12 @@ class OListProcessor(BlockProcessor):
         if sibling is not None and sibling.tag in self.SIBLING_TAGS:
             # Previous block was a list item, so set that as parent
             lst = sibling
-            # make sure previous item is in a p- if the item has text, then it
-            # it isn't in a p
-            if lst[-1].text: 
-                # since it's possible there are other children for this sibling,
-                # we can't just SubElement the p, we need to insert it as the 
-                # first item
+            # make sure previous item is in a p- if the item has text,
+            # then it isn't in a p
+            if lst[-1].text:
+                # since it's possible there are other children for this
+                # sibling, we can't just SubElement the p, we need to
+                # insert it as the first item.
                 p = util.etree.Element('p')
                 p.text = lst[-1].text
                 lst[-1].text = ''
@@ -347,7 +350,7 @@ class OListProcessor(BlockProcessor):
             self.parser.parseBlocks(li, [firstitem])
             self.parser.state.reset()
         elif parent.tag in ['ol', 'ul']:
-            # this catches the edge case of a multi-item indented list whose 
+            # this catches the edge case of a multi-item indented list whose
             # first item is in a blank parent-list item:
             # * * subitem1
             #     * subitem2
@@ -357,7 +360,7 @@ class OListProcessor(BlockProcessor):
             # This is a new list so create parent with appropriate tag.
             lst = util.etree.SubElement(parent, self.TAG)
             # Check if a custom start integer is set
-            if not self.parser.markdown.lazy_ol and self.STARTSWITH !='1':
+            if not self.parser.markdown.lazy_ol and self.STARTSWITH != '1':
                 lst.attrib['start'] = self.STARTSWITH
 
         self.parser.state.set('list')
@@ -381,7 +384,7 @@ class OListProcessor(BlockProcessor):
             if m:
                 # This is a new list item
                 # Check first item for the start index
-                if not items and self.TAG=='ol':
+                if not items and self.TAG == 'ol':
                     # Detect the integer value of first list item
                     INTEGER_RE = re.compile('(\d+)')
                     self.STARTSWITH = INTEGER_RE.match(m.group(1)).group()
@@ -420,8 +423,8 @@ class HashHeaderProcessor(BlockProcessor):
         block = blocks.pop(0)
         m = self.RE.search(block)
         if m:
-            before = block[:m.start()] # All lines before header
-            after = block[m.end():]    # All lines after header
+            before = block[:m.start()]  # All lines before header
+            after = block[m.end():]     # All lines after header
             if before:
                 # As the header was not the first line of the block and the
                 # lines before the header must be parsed first,
@@ -433,7 +436,7 @@ class HashHeaderProcessor(BlockProcessor):
             if after:
                 # Insert remaining lines as first block for future parsing.
                 blocks.insert(0, after)
-        else: #pragma: no cover
+        else:  # pragma: no cover
             # This should never happen, but just in case...
             logger.warn("We've got a problem header: %r" % block)
 
@@ -495,7 +498,6 @@ class HRProcessor(BlockProcessor):
             blocks.insert(0, postlines)
 
 
-
 class EmptyBlockProcessor(BlockProcessor):
     """ Process blocks that are empty or start with an empty line. """
 
@@ -515,9 +517,12 @@ class EmptyBlockProcessor(BlockProcessor):
                 # Add remaining lines to master blocks for later.
                 blocks.insert(0, theRest)
         sibling = self.lastChild(parent)
-        if sibling is not None and sibling.tag == 'pre' and len(sibling) and sibling[0].tag == 'code':
+        if (sibling is not None and sibling.tag == 'pre' and
+           len(sibling) and sibling[0].tag == 'code'):
             # Last block is a codeblock. Append to preserve whitespace.
-            sibling[0].text = util.AtomicString('%s%s' % (sibling[0].text, filler))
+            sibling[0].text = util.AtomicString(
+                '%s%s' % (sibling[0].text, filler)
+            )
 
 
 class ParagraphProcessor(BlockProcessor):
@@ -533,7 +538,7 @@ class ParagraphProcessor(BlockProcessor):
             if self.parser.state.isstate('list'):
                 # The parent is a tight-list.
                 #
-                # Check for any children. This will likely only happen in a 
+                # Check for any children. This will likely only happen in a
                 # tight-list when a header isn't followed by a blank line.
                 # For example:
                 #

--- a/markdown/extensions/__init__.py
+++ b/markdown/extensions/__init__.py
@@ -7,9 +7,10 @@ from __future__ import unicode_literals
 from ..util import parseBoolValue
 import warnings
 
+
 class Extension(object):
     """ Base class for extensions to subclass. """
-    
+
     # Default config -- to be overriden by a subclass
     # Must be of the following format:
     #     {
@@ -18,31 +19,36 @@ class Extension(object):
     # Note that Extension.setConfig will raise a KeyError
     # if a default is not set here.
     config = {}
-    
+
     def __init__(self, *args, **kwargs):
         """ Initiate Extension and set up configs. """
 
         # check for configs arg for backward compat.
         # (there only ever used to be one so we use arg[0])
         if len(args):
-            self.setConfigs(args[0])
-            warnings.warn('Extension classes accepting positional args is pending Deprecation. '
-                          'Each setting should be passed into the Class as a keyword. Positional '
-                          'args will be deprecated in version 2.6 and raise an error in version '
-                          '2.7. See the Release Notes for Python-Markdown version 2.5 for more info.',
-                          PendingDeprecationWarning)
+            if args[0] is not None:
+                self.setConfigs(args[0])
+            warnings.warn('Extension classes accepting positional args is '
+                          'pending Deprecation. Each setting should be '
+                          'passed into the Class as a keyword. Positional '
+                          'args are deprecated and will raise '
+                          'an error in version 2.7. See the Release Notes for '
+                          'Python-Markdown version 2.6 for more info.',
+                          DeprecationWarning)
         # check for configs kwarg for backward compat.
         if 'configs' in kwargs.keys():
-            self.setConfigs(kwargs.pop('configs', {}))
-            warnings.warn('Extension classes accepting a dict on the single keyword "config" is '
-                          'pending Deprecation. Each setting should be passed into the Class as '
-                          'a keyword directly. The "config" keyword will be deprecated in version '
-                          '2.6 and raise an error in version 2.7. See the Release Notes for '
-                          'Python-Markdown version 2.5 for more info.',
-                          PendingDeprecationWarning)
+            if kwargs['configs'] is not None:
+                self.setConfigs(kwargs.pop('configs', {}))
+            warnings.warn('Extension classes accepting a dict on the single '
+                          'keyword "config" is pending Deprecation. Each '
+                          'setting should be passed into the Class as a '
+                          'keyword directly. The "config" keyword is '
+                          'deprecated and raise an error in '
+                          'version 2.7. See the Release Notes for '
+                          'Python-Markdown version 2.6 for more info.',
+                          DeprecationWarning)
         # finally, use kwargs
         self.setConfigs(kwargs)
-            
 
     def getConfig(self, key, default=''):
         """ Return a setting for the given key or an empty string. """
@@ -88,6 +94,7 @@ class Extension(object):
         * md_globals: Global variables in the markdown module namespace.
 
         """
-        raise NotImplementedError('Extension "%s.%s" must define an "extendMarkdown"' \
-            'method.' % (self.__class__.__module__, self.__class__.__name__))
-
+        raise NotImplementedError(
+            'Extension "%s.%s" must define an "extendMarkdown"'
+            'method.' % (self.__class__.__module__, self.__class__.__name__)
+        )

--- a/markdown/extensions/abbr.py
+++ b/markdown/extensions/abbr.py
@@ -4,7 +4,7 @@ Abbreviation Extension for Python-Markdown
 
 This extension adds abbreviation handling to Python-Markdown.
 
-See <https://pythonhosted.org/Markdown/extensions/abbreviations.html> 
+See <https://pythonhosted.org/Markdown/extensions/abbreviations.html>
 for documentation.
 
 Oringinal code Copyright 2007-2008 [Waylan Limberg](http://achinghead.com/) and
@@ -12,7 +12,7 @@ Oringinal code Copyright 2007-2008 [Waylan Limberg](http://achinghead.com/) and
 
 All changes Copyright 2008-2014 The Python Markdown Project
 
-License: [BSD](http://www.opensource.org/licenses/bsd-license.php) 
+License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
 
 '''
 
@@ -27,14 +27,15 @@ import re
 # Global Vars
 ABBR_REF_RE = re.compile(r'[*]\[(?P<abbr>[^\]]*)\][ ]?:\s*(?P<title>.*)')
 
+
 class AbbrExtension(Extension):
     """ Abbreviation Extension for Python-Markdown. """
 
     def extendMarkdown(self, md, md_globals):
         """ Insert AbbrPreprocessor before ReferencePreprocessor. """
         md.preprocessors.add('abbr', AbbrPreprocessor(md), '<reference')
-        
-           
+
+
 class AbbrPreprocessor(Preprocessor):
     """ Abbreviation Preprocessor - parse text for abbr references. """
 
@@ -42,7 +43,7 @@ class AbbrPreprocessor(Preprocessor):
         '''
         Find and remove all Abbreviation references from the text.
         Each reference is set as a new AbbrPattern in the markdown instance.
-        
+
         '''
         new_text = []
         for line in lines:
@@ -50,19 +51,19 @@ class AbbrPreprocessor(Preprocessor):
             if m:
                 abbr = m.group('abbr').strip()
                 title = m.group('title').strip()
-                self.markdown.inlinePatterns['abbr-%s'%abbr] = \
+                self.markdown.inlinePatterns['abbr-%s' % abbr] = \
                     AbbrPattern(self._generate_pattern(abbr), title)
             else:
                 new_text.append(line)
         return new_text
-    
+
     def _generate_pattern(self, text):
         '''
-        Given a string, returns an regex pattern to match that string. 
-        
-        'HTML' -> r'(?P<abbr>[H][T][M][L])' 
-        
-        Note: we force each char as a literal match (in brackets) as we don't 
+        Given a string, returns an regex pattern to match that string.
+
+        'HTML' -> r'(?P<abbr>[H][T][M][L])'
+
+        Note: we force each char as a literal match (in brackets) as we don't
         know what they will be beforehand.
 
         '''
@@ -84,6 +85,7 @@ class AbbrPattern(Pattern):
         abbr.text = AtomicString(m.group('abbr'))
         abbr.set('title', self.title)
         return abbr
+
 
 def makeExtension(*args, **kwargs):
     return AbbrExtension(*args, **kwargs)

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -4,16 +4,16 @@ Admonition extension for Python-Markdown
 
 Adds rST-style admonitions. Inspired by [rST][] feature with the same name.
 
-[rST]: http://docutils.sourceforge.net/docs/ref/rst/directives.html#specific-admonitions
+[rST]: http://docutils.sourceforge.net/docs/ref/rst/directives.html#specific-admonitions  # noqa
 
-See <https://pythonhosted.org/Markdown/extensions/admonition.html> 
+See <https://pythonhosted.org/Markdown/extensions/admonition.html>
 for documentation.
 
 Original code Copyright [Tiago Serafim](http://www.tiagoserafim.com/).
 
 All changes Copyright The Python Markdown Project
 
-License: [BSD](http://www.opensource.org/licenses/bsd-license.php) 
+License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
 
 """
 
@@ -46,8 +46,8 @@ class AdmonitionProcessor(BlockProcessor):
     def test(self, parent, block):
         sibling = self.lastChild(parent)
         return self.RE.search(block) or \
-            (block.startswith(' ' * self.tab_length) and sibling and \
-                sibling.get('class', '').find(self.CLASSNAME) != -1)
+            (block.startswith(' ' * self.tab_length) and sibling is not None and
+             sibling.get('class', '').find(self.CLASSNAME) != -1)
 
     def run(self, parent, blocks):
         sibling = self.lastChild(parent)
@@ -82,7 +82,8 @@ class AdmonitionProcessor(BlockProcessor):
         klass, title = match.group(1).lower(), match.group(2)
         if title is None:
             # no title was provided, use the capitalized classname as title
-            # e.g.: `!!! note` will render `<p class="admonition-title">Note</p>`
+            # e.g.: `!!! note` will render
+            # `<p class="admonition-title">Note</p>`
             title = klass.capitalize()
         elif title == '':
             # an explicit blank title should not be rendered
@@ -93,4 +94,3 @@ class AdmonitionProcessor(BlockProcessor):
 
 def makeExtension(*args, **kwargs):
     return AdmonitionExtension(*args, **kwargs)
-

--- a/markdown/extensions/attr_list.py
+++ b/markdown/extensions/attr_list.py
@@ -2,18 +2,18 @@
 Attribute List Extension for Python-Markdown
 ============================================
 
-Adds attribute list syntax. Inspired by 
+Adds attribute list syntax. Inspired by
 [maruku](http://maruku.rubyforge.org/proposal.html#attribute_lists)'s
 feature of the same name.
 
-See <https://pythonhosted.org/Markdown/extensions/attr_list.html> 
+See <https://pythonhosted.org/Markdown/extensions/attr_list.html>
 for documentation.
 
 Original code Copyright 2011 [Waylan Limberg](http://achinghead.com/).
 
 All changes Copyright 2011-2014 The Python Markdown Project
 
-License: [BSD](http://www.opensource.org/licenses/bsd-license.php) 
+License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
 
 """
 
@@ -26,20 +26,24 @@ import re
 
 try:
     Scanner = re.Scanner
-except AttributeError: #pragma: no cover
+except AttributeError:  # pragma: no cover
     # must be on Python 2.4
     from sre import Scanner
+
 
 def _handle_double_quote(s, t):
     k, v = t.split('=')
     return k, v.strip('"')
 
+
 def _handle_single_quote(s, t):
     k, v = t.split('=')
     return k, v.strip("'")
 
-def _handle_key_value(s, t): 
+
+def _handle_key_value(s, t):
     return t.split('=')
+
 
 def _handle_word(s, t):
     if t.startswith('.'):
@@ -51,27 +55,31 @@ def _handle_word(s, t):
 _scanner = Scanner([
     (r'[^ ]+=".*?"', _handle_double_quote),
     (r"[^ ]+='.*?'", _handle_single_quote),
-    (r'[^ ]+=[^ ]*', _handle_key_value),
-    (r'[^ ]+', _handle_word),
+    (r'[^ ]+=[^ =]+', _handle_key_value),
+    (r'[^ =]+', _handle_word),
     (r' ', None)
 ])
+
 
 def get_attrs(str):
     """ Parse attribute list and return a list of attribute tuples. """
     return _scanner.scan(str)[0]
 
+
 def isheader(elem):
     return elem.tag in ['h1', 'h2', 'h3', 'h4', 'h5', 'h6']
 
+
 class AttrListTreeprocessor(Treeprocessor):
-    
+
     BASE_RE = r'\{\:?([^\}]*)\}'
     HEADER_RE = re.compile(r'[ ]+%s[ ]*$' % BASE_RE)
     BLOCK_RE = re.compile(r'\n[ ]*%s[ ]*$' % BASE_RE)
     INLINE_RE = re.compile(r'^%s' % BASE_RE)
-    NAME_RE = re.compile(r'[^A-Z_a-z\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u02ff\u0370-\u037d'
-                         r'\u037f-\u1fff\u200c-\u200d\u2070-\u218f\u2c00-\u2fef'
-                         r'\u3001-\ud7ff\uf900-\ufdcf\ufdf0-\ufffd'
+    NAME_RE = re.compile(r'[^A-Z_a-z\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u02ff'
+                         r'\u0370-\u037d\u037f-\u1fff\u200c-\u200d'
+                         r'\u2070-\u218f\u2c00-\u2fef\u3001-\ud7ff'
+                         r'\uf900-\ufdcf\ufdf0-\ufffd'
                          r'\:\-\.0-9\u00b7\u0300-\u036f\u203f-\u2040]+')
 
     def run(self, doc):
@@ -160,7 +168,9 @@ class AttrListTreeprocessor(Treeprocessor):
 
 class AttrListExtension(Extension):
     def extendMarkdown(self, md, md_globals):
-        md.treeprocessors.add('attr_list', AttrListTreeprocessor(md), '>prettify')
+        md.treeprocessors.add(
+            'attr_list', AttrListTreeprocessor(md), '>prettify'
+        )
 
 
 def makeExtension(*args, **kwargs):

--- a/markdown/extensions/codehilite.py
+++ b/markdown/extensions/codehilite.py
@@ -4,7 +4,7 @@ CodeHilite Extension for Python-Markdown
 
 Adds code/syntax highlighting to standard Python-Markdown code blocks.
 
-See <https://pythonhosted.org/Markdown/extensions/code_hilite.html> 
+See <https://pythonhosted.org/Markdown/extensions/code_hilite.html>
 for documentation.
 
 Original code Copyright 2006-2008 [Waylan Limberg](http://achinghead.com/).
@@ -18,8 +18,9 @@ License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
 from __future__ import absolute_import
 from __future__ import unicode_literals
 from . import Extension
+from .. import util
 from ..treeprocessors import Treeprocessor
-import warnings
+
 try:
     import sys
     if sys.version_info >= (3, 0):
@@ -55,7 +56,7 @@ def parse_hl_lines(expr):
 # ------------------ The Main CodeHilite Class ----------------------
 class CodeHilite(object):
     """
-    Determine language of source code, and pass it into the pygments hilighter.
+    Determine language of source code, and pass it into pygments hilighter.
 
     Basic Usage:
         >>> code = CodeHilite(src = 'some text')
@@ -63,10 +64,11 @@ class CodeHilite(object):
 
     * src: Source string or any object with a .readline attribute.
 
-    * linenums: (Boolean) Set line numbering to 'on' (True), 'off' (False) or 'auto'(None). 
-    Set to 'auto' by default.
+    * linenums: (Boolean) Set line numbering to 'on' (True),
+      'off' (False) or 'auto'(None). Set to 'auto' by default.
 
-    * guess_lang: (Boolean) Turn language auto-detection 'on' or 'off' (on by default).
+    * guess_lang: (Boolean) Turn language auto-detection
+      'on' or 'off' (on by default).
 
     * css_class: Set class name of wrapper div ('codehilite' by default).
 
@@ -75,14 +77,14 @@ class CodeHilite(object):
     Low Level Usage:
         >>> code = CodeHilite()
         >>> code.src = 'some text' # String or anything with a .readline attr.
-        >>> code.linenos = True  # True or False; Turns line numbering on or of.
+        >>> code.linenos = True  # Turns line numbering on or of.
         >>> html = code.hilite()
 
     """
 
     def __init__(self, src=None, linenums=None, guess_lang=True,
-                css_class="codehilite", lang=None, style='default',
-                noclasses=False, tab_length=4, hl_lines=None):
+                 css_class="codehilite", lang=None, style='default',
+                 noclasses=False, tab_length=4, hl_lines=None, use_pygments=True):
         self.src = src
         self.lang = lang
         self.linenums = linenums
@@ -92,6 +94,7 @@ class CodeHilite(object):
         self.noclasses = noclasses
         self.tab_length = tab_length
         self.hl_lines = hl_lines or []
+        self.use_pygments = use_pygments
 
     def hilite(self):
         """
@@ -109,7 +112,7 @@ class CodeHilite(object):
         if self.lang is None:
             self._parseHeader()
 
-        if pygments:
+        if pygments and self.use_pygments:
             try:
                 lexer = get_lexer_by_name(self.lang)
             except ValueError:
@@ -139,9 +142,9 @@ class CodeHilite(object):
                 classes.append('linenums')
             class_str = ''
             if classes:
-                class_str = ' class="%s"' % ' '.join(classes) 
-            return '<pre class="%s"><code%s>%s</code></pre>\n'% \
-                        (self.css_class, class_str, txt)
+                class_str = ' class="%s"' % ' '.join(classes)
+            return '<pre class="%s"><code%s>%s</code></pre>\n' % \
+                   (self.css_class, class_str, txt)
 
     def _parseHeader(self):
         """
@@ -149,8 +152,8 @@ class CodeHilite(object):
         line should be removed or left in place. If the sheband line contains a
         path (even a single /) then it is assumed to be a real shebang line and
         left alone. However, if no path is given (e.i.: #!python or :::python)
-        then it is assumed to be a mock shebang for language identifitation of a
-        code fragment and removed from the code block prior to processing for
+        then it is assumed to be a mock shebang for language identifitation of
+        a code fragment and removed from the code block prior to processing for
         code highlighting. When a mock shebang (e.i: #!python) is found, line
         numbering is turned on. When colons are found in place of a shebang
         (e.i.: :::python), line numbering is left in the current state - off
@@ -163,9 +166,9 @@ class CodeHilite(object):
 
         import re
 
-        #split text into lines
+        # split text into lines
         lines = self.src.split("\n")
-        #pull first line to examine
+        # pull first line to examine
         fl = lines.pop(0)
 
         c = re.compile(r'''
@@ -199,24 +202,27 @@ class CodeHilite(object):
         self.src = "\n".join(lines).strip("\n")
 
 
-
 # ------------------ The Markdown Extension -------------------------------
+
+
 class HiliteTreeprocessor(Treeprocessor):
     """ Hilight source code in code blocks. """
 
     def run(self, root):
         """ Find code blocks and store in htmlStash. """
-        blocks = root.getiterator('pre')
+        blocks = util.iterate(root, 'pre')
         for block in blocks:
-            children = block.getchildren()
-            if len(children) == 1 and children[0].tag == 'code':
-                code = CodeHilite(children[0].text,
-                            linenums=self.config['linenums'],
-                            guess_lang=self.config['guess_lang'],
-                            css_class=self.config['css_class'],
-                            style=self.config['pygments_style'],
-                            noclasses=self.config['noclasses'],
-                            tab_length=self.markdown.tab_length)
+            if len(block) == 1 and block[0].tag == 'code':
+                code = CodeHilite(
+                    block[0].text,
+                    linenums=self.config['linenums'],
+                    guess_lang=self.config['guess_lang'],
+                    css_class=self.config['css_class'],
+                    style=self.config['pygments_style'],
+                    noclasses=self.config['noclasses'],
+                    tab_length=self.markdown.tab_length,
+                    use_pygments=self.config['use_pygments']
+                )
                 placeholder = self.markdown.htmlStash.store(code.hilite(),
                                                             safe=True)
                 # Clear codeblock in etree instance
@@ -233,13 +239,23 @@ class CodeHiliteExtension(Extension):
     def __init__(self, *args, **kwargs):
         # define default configs
         self.config = {
-            'linenums': [None, "Use lines numbers. True=yes, False=no, None=auto"],
-            'force_linenos' : [False, "Depreciated! Use 'linenums' instead. Force line numbers - Default: False"],
-            'guess_lang' : [True, "Automatic language detection - Default: True"],
-            'css_class' : ["codehilite",
-                           "Set class name for wrapper <div> - Default: codehilite"],
-            'pygments_style' : ['default', 'Pygments HTML Formatter Style (Colorscheme) - Default: default'],
-            'noclasses': [False, 'Use inline styles instead of CSS classes - Default false']
+            'linenums': [None,
+                         "Use lines numbers. True=yes, False=no, None=auto"],
+            'guess_lang': [True,
+                           "Automatic language detection - Default: True"],
+            'css_class': ["codehilite",
+                          "Set class name for wrapper <div> - "
+                          "Default: codehilite"],
+            'pygments_style': ['default',
+                               'Pygments HTML Formatter Style '
+                               '(Colorscheme) - Default: default'],
+            'noclasses': [False,
+                          'Use inline styles instead of CSS classes - '
+                          'Default false'],
+            'use_pygments': [True,
+                             'Use Pygments to Highlight code blocks. '
+                             'Disable if using a JavaScript library. '
+                             'Default: True']
             }
 
         super(CodeHiliteExtension, self).__init__(*args, **kwargs)
@@ -254,4 +270,4 @@ class CodeHiliteExtension(Extension):
 
 
 def makeExtension(*args, **kwargs):
-  return CodeHiliteExtension(*args, **kwargs)
+    return CodeHiliteExtension(*args, **kwargs)

--- a/markdown/extensions/def_list.py
+++ b/markdown/extensions/def_list.py
@@ -4,14 +4,14 @@ Definition List Extension for Python-Markdown
 
 Adds parsing of Definition Lists to Python-Markdown.
 
-See <https://pythonhosted.org/Markdown/extensions/definition_lists.html> 
+See <https://pythonhosted.org/Markdown/extensions/definition_lists.html>
 for documentation.
 
 Original code Copyright 2008 [Waylan Limberg](http://achinghead.com)
 
 All changes Copyright 2008-2014 The Python Markdown Project
 
-License: [BSD](http://www.opensource.org/licenses/bsd-license.php) 
+License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
 
 """
 
@@ -36,7 +36,8 @@ class DefListProcessor(BlockProcessor):
 
         raw_block = blocks.pop(0)
         m = self.RE.search(raw_block)
-        terms = [l.strip() for l in raw_block[:m.start()].split('\n') if l.strip()]
+        terms = [l.strip() for l in
+                 raw_block[:m.start()].split('\n') if l.strip()]
         block = raw_block[m.end():]
         no_indent = self.NO_INDENT_RE.match(block)
         if no_indent:
@@ -49,7 +50,7 @@ class DefListProcessor(BlockProcessor):
             d = m.group(2)
         sibling = self.lastChild(parent)
         if not terms and sibling is None:
-            # This is not a definition item. Most likely a paragraph that 
+            # This is not a definition item. Most likely a paragraph that
             # starts with a colon at the begining of a document or list.
             blocks.insert(0, raw_block)
             return False
@@ -63,7 +64,7 @@ class DefListProcessor(BlockProcessor):
         else:
             state = 'list'
 
-        if sibling and sibling.tag == 'dl':
+        if sibling is not None and sibling.tag == 'dl':
             # This is another item on an existing list
             dl = sibling
             if not terms and len(dl) and dl[-1].tag == 'dd' and len(dl[-1]):
@@ -84,6 +85,7 @@ class DefListProcessor(BlockProcessor):
         if theRest:
             blocks.insert(0, theRest)
 
+
 class DefListIndentProcessor(ListIndentProcessor):
     """ Process indented children of definition list items. """
 
@@ -94,7 +96,6 @@ class DefListIndentProcessor(ListIndentProcessor):
         """ Create a new dd and parse the block with it as the parent. """
         dd = etree.SubElement(parent, 'dd')
         self.parser.parseBlocks(dd, [block])
- 
 
 
 class DefListExtension(Extension):
@@ -105,11 +106,10 @@ class DefListExtension(Extension):
         md.parser.blockprocessors.add('defindent',
                                       DefListIndentProcessor(md.parser),
                                       '>indent')
-        md.parser.blockprocessors.add('deflist', 
+        md.parser.blockprocessors.add('deflist',
                                       DefListProcessor(md.parser),
                                       '>ulist')
 
 
 def makeExtension(*args, **kwargs):
     return DefListExtension(*args, **kwargs)
-

--- a/markdown/extensions/extra.py
+++ b/markdown/extensions/extra.py
@@ -20,12 +20,12 @@ under a differant name. You could also edit the `extensions` global
 variable defined below, but be aware that such changes may be lost
 when you upgrade to any future version of Python-Markdown.
 
-See <https://pythonhosted.org/Markdown/extensions/extra.html> 
+See <https://pythonhosted.org/Markdown/extensions/extra.html>
 for documentation.
 
 Copyright The Python Markdown Project
 
-License: [BSD](http://www.opensource.org/licenses/bsd-license.php) 
+License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
 
 """
 
@@ -51,7 +51,7 @@ class ExtraExtension(Extension):
     """ Add various extensions to Markdown class."""
 
     def __init__(self, *args, **kwargs):
-        """ config is just a dumb holder which gets passed to actual ext later. """
+        """ config is a dumb holder which gets passed to actual ext later. """
         self.config = kwargs.pop('configs', {})
         self.config.update(kwargs)
 

--- a/markdown/extensions/fenced_code.py
+++ b/markdown/extensions/fenced_code.py
@@ -4,7 +4,7 @@ Fenced Code Extension for Python Markdown
 
 This extension adds Fenced Code Blocks to Python-Markdown.
 
-See <https://pythonhosted.org/Markdown/extensions/fenced_code_blocks.html> 
+See <https://pythonhosted.org/Markdown/extensions/fenced_code_blocks.html>
 for documentation.
 
 Original code Copyright 2007-2008 [Waylan Limberg](http://achinghead.com/).
@@ -12,7 +12,7 @@ Original code Copyright 2007-2008 [Waylan Limberg](http://achinghead.com/).
 
 All changes Copyright 2008-2014 The Python Markdown Project
 
-License: [BSD](http://www.opensource.org/licenses/bsd-license.php) 
+License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
 """
 
 from __future__ import absolute_import
@@ -30,8 +30,8 @@ class FencedCodeExtension(Extension):
         md.registerExtension(self)
 
         md.preprocessors.add('fenced_code_block',
-                                 FencedBlockPreprocessor(md),
-                                 ">normalize_whitespace")
+                             FencedBlockPreprocessor(md),
+                             ">normalize_whitespace")
 
 
 class FencedBlockPreprocessor(Preprocessor):
@@ -75,21 +75,26 @@ class FencedBlockPreprocessor(Preprocessor):
                 # If config is not empty, then the codehighlite extension
                 # is enabled, so we call it to highlight the code
                 if self.codehilite_conf:
-                    highliter = CodeHilite(m.group('code'),
-                            linenums=self.codehilite_conf['linenums'][0],
-                            guess_lang=self.codehilite_conf['guess_lang'][0],
-                            css_class=self.codehilite_conf['css_class'][0],
-                            style=self.codehilite_conf['pygments_style'][0],
-                            lang=(m.group('lang') or None),
-                            noclasses=self.codehilite_conf['noclasses'][0],
-                            hl_lines=parse_hl_lines(m.group('hl_lines')))
+                    highliter = CodeHilite(
+                        m.group('code'),
+                        linenums=self.codehilite_conf['linenums'][0],
+                        guess_lang=self.codehilite_conf['guess_lang'][0],
+                        css_class=self.codehilite_conf['css_class'][0],
+                        style=self.codehilite_conf['pygments_style'][0],
+                        lang=(m.group('lang') or None),
+                        noclasses=self.codehilite_conf['noclasses'][0],
+                        hl_lines=parse_hl_lines(m.group('hl_lines'))
+                    )
 
                     code = highliter.hilite()
                 else:
-                    code = self.CODE_WRAP % (lang, self._escape(m.group('code')))
+                    code = self.CODE_WRAP % (lang,
+                                             self._escape(m.group('code')))
 
                 placeholder = self.markdown.htmlStash.store(code, safe=True)
-                text = '%s\n%s\n%s'% (text[:m.start()], placeholder, text[m.end():])
+                text = '%s\n%s\n%s' % (text[:m.start()],
+                                       placeholder,
+                                       text[m.end():])
             else:
                 break
         return text.split("\n")
@@ -105,4 +110,3 @@ class FencedBlockPreprocessor(Preprocessor):
 
 def makeExtension(*args, **kwargs):
     return FencedCodeExtension(*args, **kwargs)
-

--- a/markdown/extensions/footnotes.py
+++ b/markdown/extensions/footnotes.py
@@ -4,12 +4,12 @@ Footnotes Extension for Python-Markdown
 
 Adds footnote handling to Python-Markdown.
 
-See <https://pythonhosted.org/Markdown/extensions/footnotes.html> 
+See <https://pythonhosted.org/Markdown/extensions/footnotes.html>
 for documentation.
 
 Copyright The Python Markdown Project
 
-License: [BSD](http://www.opensource.org/licenses/bsd-license.php) 
+License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
 
 """
 
@@ -25,30 +25,32 @@ from ..odict import OrderedDict
 import re
 
 FN_BACKLINK_TEXT = "zz1337820767766393qq"
-NBSP_PLACEHOLDER =  "qq3936677670287331zz"
+NBSP_PLACEHOLDER = "qq3936677670287331zz"
 DEF_RE = re.compile(r'[ ]{0,3}\[\^([^\]]*)\]:\s*(.*)')
 TABBED_RE = re.compile(r'((\t)|(    ))(.*)')
+
 
 class FootnoteExtension(Extension):
     """ Footnote Extension. """
 
-    def __init__ (self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         """ Setup configs. """
 
         self.config = {
             'PLACE_MARKER':
-                 ["///Footnotes Go Here///",
-                  "The text string that marks where the footnotes go"],
+                ["///Footnotes Go Here///",
+                 "The text string that marks where the footnotes go"],
             'UNIQUE_IDS':
-                 [False,
-                  "Avoid name collisions across "
-                  "multiple calls to reset()."],
+                [False,
+                 "Avoid name collisions across "
+                 "multiple calls to reset()."],
             "BACKLINK_TEXT":
-                 ["&#8617;",
-                  "The text string that links from the footnote to the reader's place."]
+                ["&#8617;",
+                 "The text string that links from the footnote "
+                 "to the reader's place."]
         }
         super(FootnoteExtension, self).__init__(*args, **kwargs)
-        
+
         # In multiple invocations, emit links that don't get tangled.
         self.unique_prefix = 0
 
@@ -60,23 +62,27 @@ class FootnoteExtension(Extension):
         self.parser = md.parser
         self.md = md
         # Insert a preprocessor before ReferencePreprocessor
-        md.preprocessors.add("footnote", FootnotePreprocessor(self),
-                             "<reference")
+        md.preprocessors.add(
+            "footnote", FootnotePreprocessor(self), "<reference"
+        )
         # Insert an inline pattern before ImageReferencePattern
-        FOOTNOTE_RE = r'\[\^([^\]]*)\]' # blah blah [^1] blah
-        md.inlinePatterns.add("footnote", FootnotePattern(FOOTNOTE_RE, self),
-                              "<reference")
+        FOOTNOTE_RE = r'\[\^([^\]]*)\]'  # blah blah [^1] blah
+        md.inlinePatterns.add(
+            "footnote", FootnotePattern(FOOTNOTE_RE, self), "<reference"
+        )
         # Insert a tree-processor that would actually add the footnote div
-        # This must be before all other treeprocessors (i.e., inline and 
+        # This must be before all other treeprocessors (i.e., inline and
         # codehilite) so they can run on the the contents of the div.
-        md.treeprocessors.add("footnote", FootnoteTreeprocessor(self),
-                                 "_begin")
+        md.treeprocessors.add(
+            "footnote", FootnoteTreeprocessor(self), "_begin"
+        )
         # Insert a postprocessor after amp_substitute oricessor
-        md.postprocessors.add("footnote", FootnotePostprocessor(self),
-                                  ">amp_substitute")
+        md.postprocessors.add(
+            "footnote", FootnotePostprocessor(self), ">amp_substitute"
+        )
 
     def reset(self):
-        """ Clear the footnotes on reset, and prepare for a distinct document. """
+        """ Clear footnotes on reset, and prepare for distinct document. """
         self.footnotes = OrderedDict()
         self.unique_prefix += 1
 
@@ -92,7 +98,7 @@ class FootnoteExtension(Extension):
                         return child, element, False
                 finder(child)
             return None
-                
+
         res = finder(root)
         return res
 
@@ -115,7 +121,8 @@ class FootnoteExtension(Extension):
     def makeFootnoteRefId(self, id):
         """ Return footnote back-link id. """
         if self.getConfig("UNIQUE_IDS"):
-            return 'fnref%s%d-%s' % (self.get_separator(), self.unique_prefix, id)
+            return 'fnref%s%d-%s' % (self.get_separator(),
+                                     self.unique_prefix, id)
         else:
             return 'fnref%s%s' % (self.get_separator(), id)
 
@@ -137,10 +144,13 @@ class FootnoteExtension(Extension):
             backlink = etree.Element("a")
             backlink.set("href", "#" + self.makeFootnoteRefId(id))
             if self.md.output_format not in ['html5', 'xhtml5']:
-                backlink.set("rev", "footnote") # Invalid in HTML5
+                backlink.set("rev", "footnote")  # Invalid in HTML5
             backlink.set("class", "footnote-backref")
-            backlink.set("title", "Jump back to footnote %d in the text" % \
-                            (self.footnotes.index(id)+1))
+            backlink.set(
+                "title",
+                "Jump back to footnote %d in the text" %
+                (self.footnotes.index(id)+1)
+            )
             backlink.text = FN_BACKLINK_TEXT
 
             if li.getchildren():
@@ -157,7 +167,7 @@ class FootnoteExtension(Extension):
 class FootnotePreprocessor(Preprocessor):
     """ Find all footnote references and store for later use. """
 
-    def __init__ (self, footnotes):
+    def __init__(self, footnotes):
         self.footnotes = footnotes
 
     def run(self, lines):
@@ -178,7 +188,7 @@ class FootnotePreprocessor(Preprocessor):
             if m:
                 fn, _i = self.detectTabbed(lines[i+1:])
                 fn.insert(0, m.group(2))
-                i += _i-1 # skip past footnote
+                i += _i-1  # skip past footnote
                 self.footnotes.setFootnote(m.group(1), "\n".join(fn))
             else:
                 newlines.append(lines[i])
@@ -199,16 +209,16 @@ class FootnotePreprocessor(Preprocessor):
 
         """
         items = []
-        blank_line = False # have we encountered a blank line yet?
-        i = 0 # to keep track of where we are
+        blank_line = False  # have we encountered a blank line yet?
+        i = 0  # to keep track of where we are
 
         def detab(line):
             match = TABBED_RE.match(line)
             if match:
-               return match.group(4)
+                return match.group(4)
 
         for line in lines:
-            if line.strip(): # Non-blank line
+            if line.strip():  # Non-blank line
                 detabbed_line = detab(line)
                 if detabbed_line:
                     items.append(detabbed_line)
@@ -222,23 +232,24 @@ class FootnotePreprocessor(Preprocessor):
                 else:
                     return items, i+1
 
-            else: # Blank line: _maybe_ we are done.
+            else:  # Blank line: _maybe_ we are done.
                 blank_line = True
-                i += 1 # advance
+                i += 1  # advance
 
                 # Find the next non-blank line
                 for j in range(i, len(lines)):
                     if lines[j].strip():
-                        next_line = lines[j]; break
+                        next_line = lines[j]
+                        break
                 else:
-                    break # There is no more text; we are done.
+                    break  # There is no more text; we are done.
 
                 # Check if the next non-blank line is tabbed
-                if detab(next_line): # Yes, more work to do.
+                if detab(next_line):  # Yes, more work to do.
                     items.append("")
                     continue
                 else:
-                    break # No, we are done.
+                    break  # No, we are done.
         else:
             i += 1
 
@@ -260,7 +271,7 @@ class FootnotePattern(Pattern):
             sup.set('id', self.footnotes.makeFootnoteRefId(id))
             a.set('href', '#' + self.footnotes.makeFootnoteId(id))
             if self.footnotes.md.output_format not in ['html5', 'xhtml5']:
-                a.set('rel', 'footnote') # invalid in HTML5
+                a.set('rel', 'footnote')  # invalid in HTML5
             a.set('class', 'footnote-ref')
             a.text = text_type(self.footnotes.footnotes.index(id) + 1)
             return sup
@@ -271,12 +282,12 @@ class FootnotePattern(Pattern):
 class FootnoteTreeprocessor(Treeprocessor):
     """ Build and append footnote div to end of document. """
 
-    def __init__ (self, footnotes):
+    def __init__(self, footnotes):
         self.footnotes = footnotes
 
     def run(self, root):
         footnotesDiv = self.footnotes.makeFootnotesDiv(root)
-        if footnotesDiv:
+        if footnotesDiv is not None:
             result = self.footnotes.findFootnotesPlaceholder(root)
             if result:
                 child, parent, isText = result
@@ -290,16 +301,19 @@ class FootnoteTreeprocessor(Treeprocessor):
             else:
                 root.append(footnotesDiv)
 
+
 class FootnotePostprocessor(Postprocessor):
     """ Replace placeholders with html entities. """
     def __init__(self, footnotes):
         self.footnotes = footnotes
 
     def run(self, text):
-        text = text.replace(FN_BACKLINK_TEXT, self.footnotes.getConfig("BACKLINK_TEXT"))
+        text = text.replace(
+            FN_BACKLINK_TEXT, self.footnotes.getConfig("BACKLINK_TEXT")
+        )
         return text.replace(NBSP_PLACEHOLDER, "&#160;")
+
 
 def makeExtension(*args, **kwargs):
     """ Return an instance of the FootnoteExtension """
     return FootnoteExtension(*args, **kwargs)
-

--- a/markdown/extensions/githubemoji.py
+++ b/markdown/extensions/githubemoji.py
@@ -34,35 +34,48 @@ class SimpleEmojiPattern(Pattern):
     of a Pattern.
 
     """
-    def __init__(self, pattern):
+    def __init__(self, pattern, css_class='emoji'):
+        self.css_class = css_class
         Pattern.__init__(self, pattern)
 
     def handleMatch(self, m):
-        el = util.etree.Element(
-            "img",
-            {
-                "src": GITHUB_ASSETS % m.group(2),
-                "alt": m.group(2),
-                "title": m.group(2),
-                "height": "20px",
-                "width": "20px",
-                "align": "absmiddle"
-            }
-        )
+        attributes = {
+            "src": GITHUB_ASSETS % m.group(2),
+            "alt": ":%s:" % m.group(2),
+            "title": ":%s:" % m.group(2),
+            "height": "20px",
+            "width": "20px",
+            "align": "absmiddle"
+        }
+
+        if self.css_class:
+            attributes['class'] = self.css_class
+
+        el = util.etree.Element("img", attributes)
         return el
 
 
 class GithubEmojiExtension(Extension):
     """Adds delete extension to Markdown class."""
 
+    def __init__(self, *args, **kwargs):
+        self.config = {
+            'css_class': [
+                "emoji",
+                "CSS class name to add to emoji images.  Use an empty string if you want no class"
+                "- Default: 'emoji'"
+            ]
+        }
+        super(GithubEmojiExtension, self).__init__(*args, **kwargs)
+
     def extendMarkdown(self, md, md_globals):
         """Add support for <del>test</del> tags as ~~test~~"""
-
-        md.inlinePatterns.add("github-emoji-people", SimpleEmojiPattern(RE_EMOJI_PEOPLE), "<not_strong")
-        md.inlinePatterns.add("github-emoji-nature", SimpleEmojiPattern(RE_EMOJI_NATURE), "<not_strong")
-        md.inlinePatterns.add("github-emoji-objects", SimpleEmojiPattern(RE_EMOJI_OBJECTS), "<not_strong")
-        md.inlinePatterns.add("github-emoji-places", SimpleEmojiPattern(RE_EMOJI_PLACES), "<not_strong")
-        md.inlinePatterns.add("github-emoji-symbols", SimpleEmojiPattern(RE_EMOJI_SYMBOLS), "<not_strong")
+        css_class = self.getConfigs()["css_class"]
+        md.inlinePatterns.add("github-emoji-people", SimpleEmojiPattern(RE_EMOJI_PEOPLE, css_class), "<not_strong")
+        md.inlinePatterns.add("github-emoji-nature", SimpleEmojiPattern(RE_EMOJI_NATURE, css_class), "<not_strong")
+        md.inlinePatterns.add("github-emoji-objects", SimpleEmojiPattern(RE_EMOJI_OBJECTS, css_class), "<not_strong")
+        md.inlinePatterns.add("github-emoji-places", SimpleEmojiPattern(RE_EMOJI_PLACES, css_class), "<not_strong")
+        md.inlinePatterns.add("github-emoji-symbols", SimpleEmojiPattern(RE_EMOJI_SYMBOLS, css_class), "<not_strong")
 
 
 def makeExtension(*args, **kwargs):

--- a/markdown/extensions/magiclink.py
+++ b/markdown/extensions/magiclink.py
@@ -21,10 +21,10 @@ from .. import util
 
 RE_MAIL = r'''(?x)(?i)
 (
-    (?:[\-+\w]([\w\-+]|\.(?!\.))+)    # Local part
-    @(?:[\w\-]+\.)                    # @domain part start
-    (([\w\-]|(?<!\.)\.(?!\.))*)[a-z]  # @domain.end (allow multiple dot names)
-    (?![\d\-_@])                      # Don't allow last char to be followed by these
+    (?:[\-+\w]([\w\-+]|\.(?!\.))+)        # Local part
+    @(?:[\w\-]+\.)                        # @domain part start
+    (?:(?:[\w\-]|(?<!\.)\.(?!\.))*)[a-z]  # @domain.end (allow multiple dot names)
+    (?![\d\-_@])                          # Don't allow last char to be followed by these
 )
 '''
 
@@ -35,7 +35,7 @@ RE_LINK = r'''(?x)(?i)
         (?P<www>w{3}\.)[a-z\d\-_]+(?:\.[a-z\d\-._]+)+                     # www.
     )
     /?[a-z\d\-._?,!'(){}\[\]/+&@%$#=:"|~;]*                               # url path, fragments, and query stuff
-    [a-z\d\-_~:/#@$*+=]                                                   # allowed end chars
+    [a-z\d\-_~/#@$*+=]                                                    # allowed end chars
 )
 '''
 

--- a/markdown/extensions/meta.py
+++ b/markdown/extensions/meta.py
@@ -4,14 +4,14 @@ Meta Data Extension for Python-Markdown
 
 This extension adds Meta Data handling to markdown.
 
-See <https://pythonhosted.org/Markdown/extensions/meta_data.html> 
+See <https://pythonhosted.org/Markdown/extensions/meta_data.html>
 for documentation.
 
 Original code Copyright 2007-2008 [Waylan Limberg](http://achinghead.com).
 
 All changes Copyright 2008-2014 The Python Markdown Project
 
-License: [BSD](http://www.opensource.org/licenses/bsd-license.php) 
+License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
 
 """
 
@@ -20,18 +20,25 @@ from __future__ import unicode_literals
 from . import Extension
 from ..preprocessors import Preprocessor
 import re
+import logging
+
+log = logging.getLogger('MARKDOWN')
 
 # Global Vars
 META_RE = re.compile(r'^[ ]{0,3}(?P<key>[A-Za-z0-9_-]+):\s*(?P<value>.*)')
 META_MORE_RE = re.compile(r'^[ ]{4,}(?P<value>.*)')
+BEGIN_RE = re.compile(r'^-{3}(\s.*)?')
+END_RE = re.compile(r'^(-{3}|\.{3})(\s.*)?')
+
 
 class MetaExtension (Extension):
     """ Meta-Data extension for Python-Markdown. """
 
     def extendMarkdown(self, md, md_globals):
         """ Add MetaPreprocessor to Markdown instance. """
-
-        md.preprocessors.add("meta", MetaPreprocessor(md), ">normalize_whitespace")
+        md.preprocessors.add("meta",
+                             MetaPreprocessor(md),
+                             ">normalize_whitespace")
 
 
 class MetaPreprocessor(Preprocessor):
@@ -41,11 +48,13 @@ class MetaPreprocessor(Preprocessor):
         """ Parse Meta-Data and store in Markdown.Meta. """
         meta = {}
         key = None
+        if lines and BEGIN_RE.match(lines[0]):
+            lines.pop(0)
         while lines:
             line = lines.pop(0)
-            if line.strip() == '':
-                break # blank line - done
             m1 = META_RE.match(line)
+            if line.strip() == '' or END_RE.match(line):
+                break  # blank line or end of YAML header - done
             if m1:
                 key = m1.group('key').lower().strip()
                 value = m1.group('value').strip()
@@ -60,11 +69,10 @@ class MetaPreprocessor(Preprocessor):
                     meta[key].append(m2.group('value').strip())
                 else:
                     lines.insert(0, line)
-                    break # no meta data - done
+                    break  # no meta data - done
         self.markdown.Meta = meta
         return lines
-        
+
 
 def makeExtension(*args, **kwargs):
     return MetaExtension(*args, **kwargs)
-

--- a/markdown/extensions/nl2br.py
+++ b/markdown/extensions/nl2br.py
@@ -5,14 +5,14 @@ NL2BR Extension
 A Python-Markdown extension to treat newlines as hard breaks; like
 GitHub-flavored Markdown does.
 
-See <https://pythonhosted.org/Markdown/extensions/nl2br.html> 
+See <https://pythonhosted.org/Markdown/extensions/nl2br.html>
 for documentation.
 
 Oringinal code Copyright 2011 [Brian Neal](http://deathofagremmie.com/)
 
 All changes Copyright 2011-2014 The Python Markdown Project
 
-License: [BSD](http://www.opensource.org/licenses/bsd-license.php) 
+License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
 
 """
 
@@ -23,6 +23,7 @@ from ..inlinepatterns import SubstituteTagPattern
 
 BR_RE = r'\n'
 
+
 class Nl2BrExtension(Extension):
 
     def extendMarkdown(self, md, md_globals):
@@ -32,4 +33,3 @@ class Nl2BrExtension(Extension):
 
 def makeExtension(*args, **kwargs):
     return Nl2BrExtension(*args, **kwargs)
-

--- a/markdown/extensions/sane_lists.py
+++ b/markdown/extensions/sane_lists.py
@@ -4,14 +4,14 @@ Sane List Extension for Python-Markdown
 
 Modify the behavior of Lists in Python-Markdown to act in a sane manor.
 
-See <https://pythonhosted.org/Markdown/extensions/sane_lists.html> 
+See <https://pythonhosted.org/Markdown/extensions/sane_lists.html>
 for documentation.
 
 Original code Copyright 2011 [Waylan Limberg](http://achinghead.com)
 
 All changes Copyright 2011-2014 The Python Markdown Project
 
-License: [BSD](http://www.opensource.org/licenses/bsd-license.php) 
+License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
 
 """
 
@@ -23,13 +23,13 @@ import re
 
 
 class SaneOListProcessor(OListProcessor):
-    
+
     CHILD_RE = re.compile(r'^[ ]{0,3}((\d+\.))[ ]+(.*)')
     SIBLING_TAGS = ['ol']
 
 
 class SaneUListProcessor(UListProcessor):
-    
+
     CHILD_RE = re.compile(r'^[ ]{0,3}(([*+-]))[ ]+(.*)')
     SIBLING_TAGS = ['ul']
 
@@ -45,4 +45,3 @@ class SaneListExtension(Extension):
 
 def makeExtension(*args, **kwargs):
     return SaneListExtension(*args, **kwargs)
-

--- a/markdown/extensions/smart_strong.py
+++ b/markdown/extensions/smart_strong.py
@@ -4,14 +4,14 @@ Smart_Strong Extension for Python-Markdown
 
 This extention adds smarter handling of double underscores within words.
 
-See <https://pythonhosted.org/Markdown/extensions/smart_strong.html> 
+See <https://pythonhosted.org/Markdown/extensions/smart_strong.html>
 for documentation.
 
 Original code Copyright 2011 [Waylan Limberg](http://achinghead.com)
 
 All changes Copyright 2011-2014 The Python Markdown Project
 
-License: [BSD](http://www.opensource.org/licenses/bsd-license.php) 
+License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
 
 '''
 
@@ -23,13 +23,19 @@ from ..inlinepatterns import SimpleTagPattern
 SMART_STRONG_RE = r'(?<!\w)(_{2})(?!_)(.+?)(?<!_)\2(?!\w)'
 STRONG_RE = r'(\*{2})(.+?)\2'
 
+
 class SmartEmphasisExtension(Extension):
     """ Add smart_emphasis extension to Markdown class."""
 
     def extendMarkdown(self, md, md_globals):
         """ Modify inline patterns. """
         md.inlinePatterns['strong'] = SimpleTagPattern(STRONG_RE, 'strong')
-        md.inlinePatterns.add('strong2', SimpleTagPattern(SMART_STRONG_RE, 'strong'), '>emphasis2')
+        md.inlinePatterns.add(
+            'strong2',
+            SimpleTagPattern(SMART_STRONG_RE, 'strong'),
+            '>emphasis2'
+        )
+
 
 def makeExtension(*args, **kwargs):
     return SmartEmphasisExtension(*args, **kwargs)

--- a/markdown/extensions/smarty.py
+++ b/markdown/extensions/smarty.py
@@ -3,17 +3,17 @@
 Smarty extension for Python-Markdown
 ====================================
 
-Adds conversion of ASCII dashes, quotes and ellipses to their HTML 
+Adds conversion of ASCII dashes, quotes and ellipses to their HTML
 entity equivalents.
 
-See <https://pythonhosted.org/Markdown/extensions/smarty.html> 
+See <https://pythonhosted.org/Markdown/extensions/smarty.html>
 for documentation.
 
 Author: 2013, Dmitry Shachnev <mitya57@gmail.com>
 
 All changes Copyright 2013-2014 The Python Markdown Project
 
-License: [BSD](http://www.opensource.org/licenses/bsd-license.php) 
+License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
 
 SmartyPants license:
 
@@ -32,7 +32,7 @@ SmartyPants license:
       the documentation and/or other materials provided with the
       distribution.
 
-   *  Neither the name "SmartyPants" nor the names of its contributors 
+   *  Neither the name "SmartyPants" nor the names of its contributors
       may be used to endorse or promote products derived from this
       software without specific prior written permission.
 
@@ -86,7 +86,7 @@ from . import Extension
 from ..inlinepatterns import HtmlPattern
 from ..odict import OrderedDict
 from ..treeprocessors import InlineProcessor
-from ..util import parseBoolValue
+
 
 # Constants for quote education.
 punctClass = r"""[!"#\$\%'()*+,-.\/:;<=>?\@\[\\\]\^_`{|}~]"""
@@ -94,14 +94,14 @@ endOfWordClass = r"[\s.,;:!?)]"
 closeClass = "[^\ \t\r\n\[\{\(\-\u0002\u0003]"
 
 openingQuotesBase = (
-   '(\s'              # a  whitespace char
-   '|&nbsp;'          # or a non-breaking space entity
-   '|--'              # or dashes
-   '|–|—'             # or unicode
-   '|&[mn]dash;'      # or named dash entities
-   '|&#8211;|&#8212;' # or decimal entities
-   ')'
-) 
+    '(\s'               # a  whitespace char
+    '|&nbsp;'           # or a non-breaking space entity
+    '|--'               # or dashes
+    '|–|—'              # or unicode
+    '|&[mn]dash;'       # or named dash entities
+    '|&#8211;|&#8212;'  # or decimal entities
+    ')'
+)
 
 substitutions = {
     'mdash': '&mdash;',
@@ -126,6 +126,9 @@ doubleQuoteStartRe = r'^"(?=%s\B)' % punctClass
 doubleQuoteSetsRe = r""""'(?=\w)"""
 singleQuoteSetsRe = r"""'"(?=\w)"""
 
+# Special case for decade abbreviations (the '80s):
+decadeAbbrRe = r"(?<!\w)'(?=\d{2}s)"
+
 # Get most opening double quotes:
 openingDoubleQuotesRegex = r'%s"(?=\w)' % openingQuotesBase
 
@@ -137,12 +140,13 @@ closingDoubleQuotesRegex2 = '(?<=%s)"' % closeClass
 openingSingleQuotesRegex = r"%s'(?=\w)" % openingQuotesBase
 
 # Single closing quotes:
-closingSingleQuotesRegex  = r"(?<=%s)'(?!\s|s\b|\d)" % closeClass
+closingSingleQuotesRegex = r"(?<=%s)'(?!\s|s\b|\d)" % closeClass
 closingSingleQuotesRegex2 = r"(?<=%s)'(\s|s\b)" % closeClass
 
 # All remaining quotes should be opening ones
 remainingSingleQuotesRegex = "'"
 remainingDoubleQuotesRegex = '"'
+
 
 class SubstituteTextPattern(HtmlPattern):
     def __init__(self, pattern, replace, markdown_instance):
@@ -160,6 +164,7 @@ class SubstituteTextPattern(HtmlPattern):
                 result += self.markdown.htmlStash.store(part, safe=True)
         return result
 
+
 class SmartyExtension(Extension):
     def __init__(self, *args, **kwargs):
         self.config = {
@@ -167,7 +172,7 @@ class SmartyExtension(Extension):
             'smart_angled_quotes': [False, 'Educate angled quotes'],
             'smart_dashes': [True, 'Educate dashes'],
             'smart_ellipses': [True, 'Educate ellipses'],
-            'substitutions' : [{}, 'Overwrite default substitutions'],
+            'substitutions': [{}, 'Overwrite default substitutions'],
         }
         super(SmartyExtension, self).__init__(*args, **kwargs)
         self.substitutions = dict(substitutions)
@@ -182,31 +187,40 @@ class SmartyExtension(Extension):
             self.inlinePatterns.add(name, pattern, after)
 
     def educateDashes(self, md):
-        emDashesPattern = SubstituteTextPattern(r'(?<!-)---(?!-)',
-                                            (self.substitutions['mdash'],), md)
-        enDashesPattern = SubstituteTextPattern(r'(?<!-)--(?!-)',
-                                            (self.substitutions['ndash'],), md)
+        emDashesPattern = SubstituteTextPattern(
+            r'(?<!-)---(?!-)', (self.substitutions['mdash'],), md
+        )
+        enDashesPattern = SubstituteTextPattern(
+            r'(?<!-)--(?!-)', (self.substitutions['ndash'],), md
+        )
         self.inlinePatterns.add('smarty-em-dashes', emDashesPattern, '_begin')
-        self.inlinePatterns.add('smarty-en-dashes', enDashesPattern,
-            '>smarty-em-dashes')
+        self.inlinePatterns.add(
+            'smarty-en-dashes', enDashesPattern, '>smarty-em-dashes'
+        )
 
     def educateEllipses(self, md):
-        ellipsesPattern = SubstituteTextPattern(r'(?<!\.)\.{3}(?!\.)',
-                                         (self.substitutions['ellipsis'],), md)
+        ellipsesPattern = SubstituteTextPattern(
+            r'(?<!\.)\.{3}(?!\.)', (self.substitutions['ellipsis'],), md
+        )
         self.inlinePatterns.add('smarty-ellipses', ellipsesPattern, '_begin')
 
     def educateAngledQuotes(self, md):
-        leftAngledQuotePattern = SubstituteTextPattern(r'\<\<',
-                                 (self.substitutions['left-angle-quote'],), md)
-        rightAngledQuotePattern = SubstituteTextPattern(r'\>\>',
-                                (self.substitutions['right-angle-quote'],), md)
-        self.inlinePatterns.add('smarty-left-angle-quotes',
-                                leftAngledQuotePattern, '_begin')
-        self.inlinePatterns.add('smarty-right-angle-quotes',
-                                rightAngledQuotePattern, '>smarty-left-angle-quotes')
+        leftAngledQuotePattern = SubstituteTextPattern(
+            r'\<\<', (self.substitutions['left-angle-quote'],), md
+        )
+        rightAngledQuotePattern = SubstituteTextPattern(
+            r'\>\>', (self.substitutions['right-angle-quote'],), md
+        )
+        self.inlinePatterns.add(
+            'smarty-left-angle-quotes', leftAngledQuotePattern, '_begin'
+        )
+        self.inlinePatterns.add(
+            'smarty-right-angle-quotes',
+            rightAngledQuotePattern,
+            '>smarty-left-angle-quotes'
+        )
 
     def educateQuotes(self, md):
-        configs = self.getConfigs()
         lsquo = self.substitutions['left-single-quote']
         rsquo = self.substitutions['right-single-quote']
         ldquo = self.substitutions['left-double-quote']
@@ -216,6 +230,7 @@ class SmartyExtension(Extension):
             (doubleQuoteStartRe, (rdquo,)),
             (doubleQuoteSetsRe, (ldquo + lsquo,)),
             (singleQuoteSetsRe, (lsquo + ldquo,)),
+            (decadeAbbrRe, (rsquo,)),
             (openingSingleQuotesRegex, (2, lsquo)),
             (closingSingleQuotesRegex, (rsquo,)),
             (closingSingleQuotesRegex2, (rsquo, 2)),
@@ -242,6 +257,7 @@ class SmartyExtension(Extension):
         inlineProcessor.inlinePatterns = self.inlinePatterns
         md.treeprocessors.add('smarty', inlineProcessor, '_end')
         md.ESCAPED_CHARS.extend(['"', "'"])
+
 
 def makeExtension(*args, **kwargs):
     return SmartyExtension(*args, **kwargs)

--- a/markdown/extensions/superfences.py
+++ b/markdown/extensions/superfences.py
@@ -189,10 +189,11 @@ class SuperFencesBlockPreprocessor(Preprocessor):
     def check_codehilite(self):
         """ Check for code hilite extension """
         if not self.checked_for_codehilite:
-            for ext in self.markdown.registeredExtensions:
-                if isinstance(ext, CodeHiliteExtension):
-                    self.codehilite_conf = ext.config
-                    break
+            if CodeHilite:
+                for ext in self.markdown.registeredExtensions:
+                    if isinstance(ext, CodeHiliteExtension):
+                        self.codehilite_conf = ext.config
+                        break
             self.checked_for_codehilite = True
 
     def clear(self):
@@ -341,7 +342,7 @@ class SuperFencesBlockPreprocessor(Preprocessor):
         If config is not empty, then the codehlite extension
         is enabled, so we call into to highlight the code.
         """
-        if self.codehilite_conf:
+        if CodeHilite and self.codehilite_conf:
             code = CodeHilite(
                 source,
                 linenums=self.codehilite_conf['linenums'][0],
@@ -350,7 +351,8 @@ class SuperFencesBlockPreprocessor(Preprocessor):
                 style=self.codehilite_conf['pygments_style'][0],
                 lang=language,
                 noclasses=self.codehilite_conf['noclasses'][0],
-                hl_lines=parse_hl_lines(self.hl_lines)
+                hl_lines=parse_hl_lines(self.hl_lines),
+                use_pygments=self.codehilite_conf['use_pygments'][0]
             ).hilite()
         else:
             lang = self.CLASS_ATTR % language if language else ''

--- a/markdown/extensions/tables.py
+++ b/markdown/extensions/tables.py
@@ -4,7 +4,7 @@ Tables Extension for Python-Markdown
 
 Added parsing of tables to Python-Markdown.
 
-See <https://pythonhosted.org/Markdown/extensions/tables.html> 
+See <https://pythonhosted.org/Markdown/extensions/tables.html>
 for documentation.
 
 Original code Copyright 2009 [Waylan Limberg](http://achinghead.com)
@@ -21,13 +21,14 @@ from . import Extension
 from ..blockprocessors import BlockProcessor
 from ..util import etree
 
+
 class TableProcessor(BlockProcessor):
     """ Process Tables. """
 
     def test(self, parent, block):
         rows = block.split('\n')
-        return (len(rows) > 2 and '|' in rows[0] and 
-                '|' in rows[1] and '-' in rows[1] and 
+        return (len(rows) > 1 and '|' in rows[0] and
+                '|' in rows[1] and '-' in rows[1] and
                 rows[1].strip()[0] in ['|', ':', '-'])
 
     def run(self, parent, blocks):
@@ -35,7 +36,7 @@ class TableProcessor(BlockProcessor):
         block = blocks.pop(0).split('\n')
         header = block[0].strip()
         seperator = block[1].strip()
-        rows = block[2:]
+        rows = [] if len(block) < 3 else block[2:]
         # Get format type (bordered by pipes or not)
         border = False
         if header.startswith('|'):
@@ -66,13 +67,13 @@ class TableProcessor(BlockProcessor):
         if parent.tag == 'thead':
             tag = 'th'
         cells = self._split_row(row, border)
-        # We use align here rather than cells to ensure every row 
+        # We use align here rather than cells to ensure every row
         # contains the same number of columns.
         for i, a in enumerate(align):
             c = etree.SubElement(tr, tag)
             try:
                 c.text = cells[i].strip()
-            except IndexError: #pragma: no cover
+            except IndexError:  # pragma: no cover
                 c.text = ""
             if a:
                 c.set('align', a)
@@ -92,11 +93,10 @@ class TableExtension(Extension):
 
     def extendMarkdown(self, md, md_globals):
         """ Add an instance of TableProcessor to BlockParser. """
-        md.parser.blockprocessors.add('table', 
+        md.parser.blockprocessors.add('table',
                                       TableProcessor(md.parser),
                                       '<hashheader')
 
 
 def makeExtension(*args, **kwargs):
     return TableExtension(*args, **kwargs)
-

--- a/markdown/extensions/tasklist.py
+++ b/markdown/extensions/tasklist.py
@@ -18,6 +18,7 @@ from __future__ import unicode_literals
 from ..extensions import Extension
 from ..treeprocessors import Treeprocessor
 import re
+from .. import util
 
 RE_CHECKBOX = re.compile(r"^(?P<checkbox> *\[(?P<state>(?:x|X| ){1})\] +)(?P<line>.*)")
 
@@ -58,9 +59,9 @@ class TasklistTreeprocessor(Treeprocessor):
     def run(self, root):
         """ Find list items that start with [ ] or [x] or [X] """
 
-        parent_map = dict((c, p) for p in root.getiterator() for c in p)
+        parent_map = dict((c, p) for p in util.iterate(root) for c in p)
         task_items = []
-        lilinks = root.getiterator('li')
+        lilinks = util.iterate(root, 'li')
         for li in lilinks:
             if li.text is None or li.text == "":
                 if not self.sub_paragraph(li):

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -2,14 +2,14 @@
 Table of Contents Extension for Python-Markdown
 ===============================================
 
-See <https://pythonhosted.org/Markdown/extensions/toc.html> 
+See <https://pythonhosted.org/Markdown/extensions/toc.html>
 for documentation.
 
 Oringinal code Copyright 2008 [Jack Miller](http://codezen.org)
 
 All changes Copyright 2008-2014 The Python Markdown Project
 
-License: [BSD](http://www.opensource.org/licenses/bsd-license.php) 
+License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
 
 """
 
@@ -17,12 +17,51 @@ from __future__ import absolute_import
 from __future__ import unicode_literals
 from . import Extension
 from ..treeprocessors import Treeprocessor
-from ..util import etree, parseBoolValue, AMP_SUBSTITUTE
-from .headerid import slugify, unique, itertext, stashedHTML2text
+from ..util import etree, parseBoolValue, AMP_SUBSTITUTE, HTML_PLACEHOLDER_RE, string_type, iterate, \
+    itertext
 import re
+import unicodedata
 
 
-def order_toc_list(toc_list):
+def slugify(value, separator):
+    """ Slugify a string, to make it URL friendly. """
+    value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore')
+    value = re.sub('[^\w\s-]', '', value.decode('ascii')).strip().lower()
+    return re.sub('[%s\s]+' % separator, separator, value)
+
+
+IDCOUNT_RE = re.compile(r'^(.*)_([0-9]+)$')
+
+
+def unique(id, ids):
+    """ Ensure id is unique in set of ids. Append '_1', '_2'... if not """
+    while id in ids or not id:
+        m = IDCOUNT_RE.match(id)
+        if m:
+            id = '%s_%d' % (m.group(1), int(m.group(2))+1)
+        else:
+            id = '%s_%d' % (id, 1)
+    ids.add(id)
+    return id
+
+
+def stashedHTML2text(text, md):
+    """ Extract raw HTML from stash, reduce to plain text and swap with placeholder. """
+    def _html_sub(m):
+        """ Substitute raw html with plain text. """
+        try:
+            raw, safe = md.htmlStash.rawHtmlBlocks[int(m.group(1))]
+        except (IndexError, TypeError):  # pragma: no cover
+            return m.group(0)
+        if md.safeMode and not safe:  # pragma: no cover
+            return ''
+        # Strip out tags and entities - leaveing text
+        return re.sub(r'(<[^>]+>)|(&[\#a-zA-Z0-9]+;)', '', raw)
+
+    return HTML_PLACEHOLDER_RE.sub(_html_sub, text)
+
+
+def nest_toc_tokens(toc_list):
     """Given an unsorted list with errors and skips, return a nested one.
     [{'level': 1}, {'level': 2}]
     =>
@@ -59,7 +98,7 @@ def order_toc_list(toc_list):
                 for p in reversed(parents):
                     if current_level <= p['level']:
                         to_pop += 1
-                    else:
+                    else:  # pragma: no cover
                         break
                 if to_pop:
                     levels = levels[:-to_pop]
@@ -68,9 +107,11 @@ def order_toc_list(toc_list):
                 # Note current level as last
                 levels.append(current_level)
 
-            # Level is the same, so append to the current parent (if available)
+            # Level is the same, so append to
+            # the current parent (if available)
             if current_level == levels[-1]:
-                (parents[-1]['children'] if parents else ordered_list).append(t)
+                (parents[-1]['children'] if parents
+                 else ordered_list).append(t)
 
             # Current level is > last item's level,
             # So make last item a parent and append current as child
@@ -84,20 +125,61 @@ def order_toc_list(toc_list):
 
 
 class TocTreeprocessor(Treeprocessor):
-    
-    # Iterator wrapper to get parent and child all at once
+    def __init__(self, md, config):
+        super(TocTreeprocessor, self).__init__(md)
+
+        self.marker = config["marker"]
+        self.title = config["title"]
+        self.base_level = int(config["baselevel"]) - 1
+        self.slugify = config["slugify"]
+        self.sep = config["separator"]
+        self.use_anchors = parseBoolValue(config["anchorlink"])
+        self.use_permalinks = parseBoolValue(config["permalink"], False)
+        if self.use_permalinks is None:
+            self.use_permalinks = config["permalink"]
+
+        self.header_rgx = re.compile("[Hh][123456]")
+
     def iterparent(self, root):
-        for parent in root.getiterator():
+        ''' Iterator wrapper to get parent and child all at once. '''
+        for parent in iterate(root):
             for child in parent:
                 yield parent, child
-    
-    def add_anchor(self, c, elem_id): #@ReservedAssignment
+
+    def replace_marker(self, root, elem):
+        ''' Replace marker with elem. '''
+        for (p, c) in self.iterparent(root):
+            text = ''.join(itertext(c)).strip()
+            if not text:
+                continue
+
+            # To keep the output from screwing up the
+            # validation by putting a <div> inside of a <p>
+            # we actually replace the <p> in its entirety.
+            # We do not allow the marker inside a header as that
+            # would causes an enless loop of placing a new TOC
+            # inside previously generated TOC.
+            if c.text and c.text.strip() == self.marker and \
+               not self.header_rgx.match(c.tag) and c.tag not in ['pre', 'code']:
+                for i in range(len(p)):
+                    if p[i] == c:
+                        p[i] = elem
+                        break
+
+    def set_level(self, elem):
+        ''' Adjust header level according to base level. '''
+        level = int(elem.tag[-1]) + self.base_level
+        if level > 6:
+            level = 6
+        elem.tag = 'h%d' % level
+
+    def add_anchor(self, c, elem_id):  # @ReservedAssignment
         anchor = etree.Element("a")
         anchor.text = c.text
         anchor.attrib["href"] = "#" + elem_id
         anchor.attrib["class"] = "toclink"
         c.text = ""
-        for elem in c.getchildren():
+        for elem in c:
             anchor.append(elem)
             c.remove(elem)
         c.append(anchor)
@@ -105,18 +187,23 @@ class TocTreeprocessor(Treeprocessor):
     def add_permalink(self, c, elem_id):
         permalink = etree.Element("a")
         permalink.text = ("%spara;" % AMP_SUBSTITUTE
-            if self.use_permalinks is True else self.use_permalinks)
+                          if self.use_permalinks is True
+                          else self.use_permalinks)
         permalink.attrib["href"] = "#" + elem_id
         permalink.attrib["class"] = "headerlink"
         permalink.attrib["title"] = "Permanent link"
         c.append(permalink)
-    
-    def build_toc_etree(self, div, toc_list):
+
+    def build_toc_div(self, toc_list):
+        """ Return a string div given a toc list. """
+        div = etree.Element("div")
+        div.attrib["class"] = "toc"
+
         # Add title to the div
-        if self.config["title"]:
+        if self.title:
             header = etree.SubElement(div, "span")
             header.attrib["class"] = "toctitle"
-            header.text = self.config["title"]
+            header.text = self.title
 
         def build_etree_ul(toc_list, parent):
             ul = etree.SubElement(parent, "ul")
@@ -129,114 +216,94 @@ class TocTreeprocessor(Treeprocessor):
                 if item['children']:
                     build_etree_ul(item['children'], li)
             return ul
-        
-        return build_etree_ul(toc_list, div)
-        
-    def run(self, doc):
 
-        div = etree.Element("div")
-        div.attrib["class"] = "toc"
-        header_rgx = re.compile("[Hh][123456]")
-        
-        self.use_anchors = parseBoolValue(self.config["anchorlink"])
-        self.use_permalinks = parseBoolValue(self.config["permalink"], False)
-        if self.use_permalinks is None:
-            self.use_permalinks = self.config["permalink"]
-        
+        build_etree_ul(toc_list, div)
+        prettify = self.markdown.treeprocessors.get('prettify')
+        if prettify:
+            prettify.run(div)
+        return div
+
+    def run(self, doc):
         # Get a list of id attributes
         used_ids = set()
-        for c in doc.getiterator():
-            if "id" in c.attrib:
-                used_ids.add(c.attrib["id"])
+        for el in iterate(doc):
+            if "id" in el.attrib:
+                used_ids.add(el.attrib["id"])
 
-        toc_list = []
-        marker_found = False
-        for (p, c) in self.iterparent(doc):
-            text = ''.join(itertext(c)).strip()
-            if not text:
-                continue
+        toc_tokens = []
+        for el in iterate(doc):
+            if isinstance(el.tag, string_type) and self.header_rgx.match(el.tag):
+                self.set_level(el)
+                text = ''.join(itertext(el)).strip()
 
-            # To keep the output from screwing up the
-            # validation by putting a <div> inside of a <p>
-            # we actually replace the <p> in its entirety.
-            # We do not allow the marker inside a header as that
-            # would causes an enless loop of placing a new TOC 
-            # inside previously generated TOC.
-            if c.text and c.text.strip() == self.config["marker"] and \
-               not header_rgx.match(c.tag) and c.tag not in ['pre', 'code']:
-                for i in range(len(p)):
-                    if p[i] == c:
-                        p[i] = div
-                        break
-                marker_found = True
-                            
-            if header_rgx.match(c.tag):
-                
-                # Do not override pre-existing ids 
-                if not "id" in c.attrib:
-                    elem_id = stashedHTML2text(text, self.markdown)
-                    elem_id = unique(self.config["slugify"](elem_id, '-'), used_ids)
-                    c.attrib["id"] = elem_id
-                else:
-                    elem_id = c.attrib["id"]
+                # Do not override pre-existing ids
+                if "id" not in el.attrib:
+                    innertext = stashedHTML2text(text, self.markdown)
+                    el.attrib["id"] = unique(self.slugify(innertext, self.sep), used_ids)
 
-                tag_level = int(c.tag[-1])
-                
-                toc_list.append({'level': tag_level,
-                    'id': elem_id,
-                    'name': text})
+                toc_tokens.append({
+                    'level': int(el.tag[-1]),
+                    'id': el.attrib["id"],
+                    'name': text
+                })
 
                 if self.use_anchors:
-                    self.add_anchor(c, elem_id)
+                    self.add_anchor(el, el.attrib["id"])
                 if self.use_permalinks:
-                    self.add_permalink(c, elem_id)
-                
-        toc_list_nested = order_toc_list(toc_list)
-        self.build_toc_etree(div, toc_list_nested)
-        prettify = self.markdown.treeprocessors.get('prettify')
-        if prettify: prettify.run(div)
-        if not marker_found:
-            # serialize and attach to markdown instance.
-            toc = self.markdown.serializer(div)
-            for pp in self.markdown.postprocessors.values():
-                toc = pp.run(toc)
-            self.markdown.toc = toc
+                    self.add_permalink(el, el.attrib["id"])
+
+        div = self.build_toc_div(nest_toc_tokens(toc_tokens))
+        if self.marker:
+            self.replace_marker(doc, div)
+
+        # serialize and attach to markdown instance.
+        toc = self.markdown.serializer(div)
+        for pp in self.markdown.postprocessors.values():
+            toc = pp.run(toc)
+        self.markdown.toc = toc
 
 
 class TocExtension(Extension):
-    
+
     TreeProcessorClass = TocTreeprocessor
-    
+
     def __init__(self, *args, **kwargs):
-        self.config = { 
-            "marker" : ["[TOC]", 
-                "Text to find and replace with Table of Contents - "
-                "Defaults to \"[TOC]\""],
-            "slugify" : [slugify,
-                "Function to generate anchors based on header text - "
-                "Defaults to the headerid ext's slugify function."],
-            "title" : ["",
-                "Title to insert into TOC <div> - "
-                "Defaults to an empty string"],
-            "anchorlink" : [0,
-                "1 if header should be a self link - "
-                "Defaults to 0"],
-            "permalink" : [0,
-                "1 or link text if a Sphinx-style permalink should be added - "
-                "Defaults to 0"]
+        self.config = {
+            "marker": ['[TOC]',
+                       'Text to find and replace with Table of Contents - '
+                       'Set to an empty string to disable. Defaults to "[TOC]"'],
+            "title": ["",
+                      "Title to insert into TOC <div> - "
+                      "Defaults to an empty string"],
+            "anchorlink": [False,
+                           "True if header should be a self link - "
+                           "Defaults to False"],
+            "permalink": [0,
+                          "True or link text if a Sphinx-style permalink should "
+                          "be added - Defaults to False"],
+            "baselevel": ['1', 'Base level for headers.'],
+            "slugify": [slugify,
+                        "Function to generate anchors based on header text - "
+                        "Defaults to the headerid ext's slugify function."],
+            'separator': ['-', 'Word separator. Defaults to "-".']
         }
 
         super(TocExtension, self).__init__(*args, **kwargs)
 
     def extendMarkdown(self, md, md_globals):
-        tocext = self.TreeProcessorClass(md)
-        tocext.config = self.getConfigs()
+        md.registerExtension(self)
+        self.md = md
+        self.reset()
+        tocext = self.TreeProcessorClass(md, self.getConfigs())
         # Headerid ext is set to '>prettify'. With this set to '_end',
-        # it should always come after headerid ext (and honor ids assinged 
-        # by the header id extension) if both are used. Same goes for 
+        # it should always come after headerid ext (and honor ids assinged
+        # by the header id extension) if both are used. Same goes for
         # attr_list extension. This must come last because we don't want
         # to redefine ids after toc is created. But we do want toc prettified.
         md.treeprocessors.add("toc", tocext, "_end")
+
+    def reset(self):
+        self.md.toc = ''
 
 
 def makeExtension(*args, **kwargs):

--- a/markdown/extensions/wikilinks.py
+++ b/markdown/extensions/wikilinks.py
@@ -4,14 +4,14 @@ WikiLinks Extension for Python-Markdown
 
 Converts [[WikiLinks]] to relative links.
 
-See <https://pythonhosted.org/Markdown/extensions/wikilinks.html> 
+See <https://pythonhosted.org/Markdown/extensions/wikilinks.html>
 for documentation.
 
 Original code Copyright [Waylan Limberg](http://achinghead.com/).
 
 All changes Copyright The Python Markdown Project
 
-License: [BSD](http://www.opensource.org/licenses/bsd-license.php) 
+License: [BSD](http://www.opensource.org/licenses/bsd-license.php)
 
 '''
 
@@ -22,27 +22,28 @@ from ..inlinepatterns import Pattern
 from ..util import etree
 import re
 
+
 def build_url(label, base, end):
     """ Build a url from the label, a base, and an end. """
     clean_label = re.sub(r'([ ]+_)|(_[ ]+)|([ ]+)', '_', label)
-    return '%s%s%s'% (base, clean_label, end)
+    return '%s%s%s' % (base, clean_label, end)
 
 
 class WikiLinkExtension(Extension):
 
-    def __init__ (self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         self.config = {
-            'base_url' : ['/', 'String to append to beginning or URL.'],
-            'end_url' : ['/', 'String to append to end of URL.'],
-            'html_class' : ['wikilink', 'CSS hook. Leave blank for none.'],
-            'build_url' : [build_url, 'Callable formats URL from label.'],
+            'base_url': ['/', 'String to append to beginning or URL.'],
+            'end_url': ['/', 'String to append to end of URL.'],
+            'html_class': ['wikilink', 'CSS hook. Leave blank for none.'],
+            'build_url': [build_url, 'Callable formats URL from label.'],
         }
-        
+
         super(WikiLinkExtension, self).__init__(*args, **kwargs)
-    
+
     def extendMarkdown(self, md, md_globals):
         self.md = md
-    
+
         # append to end of inline patterns
         WIKILINK_RE = r'\[\[([\w0-9_ -]+)\]\]'
         wikilinkPattern = WikiLinks(WIKILINK_RE, self.getConfigs())
@@ -54,14 +55,14 @@ class WikiLinks(Pattern):
     def __init__(self, pattern, config):
         super(WikiLinks, self).__init__(pattern)
         self.config = config
-  
+
     def handleMatch(self, m):
         if m.group(2).strip():
             base_url, end_url, html_class = self._getMeta()
             label = m.group(2).strip()
             url = self.config['build_url'](label, base_url, end_url)
             a = etree.Element('a')
-            a.text = label 
+            a.text = label
             a.set('href', url)
             if html_class:
                 a.set('class', html_class)
@@ -82,7 +83,7 @@ class WikiLinks(Pattern):
             if 'wiki_html_class' in self.md.Meta:
                 html_class = self.md.Meta['wiki_html_class'][0]
         return base_url, end_url, html_class
-    
 
-def makeExtension(*args, **kwargs) :
+
+def makeExtension(*args, **kwargs):
     return WikiLinkExtension(*args, **kwargs)

--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -46,13 +46,13 @@ from __future__ import unicode_literals
 from . import util
 from . import odict
 import re
-try: #pragma: no cover
+try:  # pragma: no cover
     from urllib.parse import urlparse, urlunparse
-except ImportError: #pragma: no cover
+except ImportError:  # pragma: no cover
     from urlparse import urlparse, urlunparse
-try: #pragma: no cover
+try:  # pragma: no cover
     from html import entities
-except ImportError: #pragma: no cover
+except ImportError:  # pragma: no cover
     import htmlentitydefs as entities
 
 
@@ -64,10 +64,12 @@ def build_inlinepatterns(md_instance, **kwargs):
     inlinePatterns["reference"] = ReferencePattern(REFERENCE_RE, md_instance)
     inlinePatterns["link"] = LinkPattern(LINK_RE, md_instance)
     inlinePatterns["image_link"] = ImagePattern(IMAGE_LINK_RE, md_instance)
-    inlinePatterns["image_reference"] = \
-            ImageReferencePattern(IMAGE_REFERENCE_RE, md_instance)
-    inlinePatterns["short_reference"] = \
-            ReferencePattern(SHORT_REF_RE, md_instance)
+    inlinePatterns["image_reference"] = ImageReferencePattern(
+        IMAGE_REFERENCE_RE, md_instance
+    )
+    inlinePatterns["short_reference"] = ReferencePattern(
+        SHORT_REF_RE, md_instance
+    )
     inlinePatterns["autolink"] = AutolinkPattern(AUTOLINK_RE, md_instance)
     inlinePatterns["automail"] = AutomailPattern(AUTOMAIL_RE, md_instance)
     inlinePatterns["linebreak"] = SubstituteTagPattern(LINE_BREAK_RE, 'br')
@@ -91,47 +93,84 @@ The actual regular expressions for patterns
 """
 
 NOBRACKET = r'[^\]\[]*'
-BRK = ( r'\[('
-        + (NOBRACKET + r'(\[')*6
-        + (NOBRACKET+ r'\])*')*6
-        + NOBRACKET + r')\]' )
+BRK = (
+    r'\[(' +
+    (NOBRACKET + r'(\[')*6 +
+    (NOBRACKET + r'\])*')*6 +
+    NOBRACKET + r')\]'
+)
 NOIMG = r'(?<!\!)'
 
-BACKTICK_RE = r'(?<!\\)(`+)(.+?)(?<!`)\2(?!`)' # `e=f()` or ``e=f("`")``
-ESCAPE_RE = r'\\(.)'                             # \<
-EMPHASIS_RE = r'(\*)([^\*]+)\2'                    # *emphasis*
-STRONG_RE = r'(\*{2}|_{2})(.+?)\2'                      # **strong**
-EM_STRONG_RE = r'(\*|_)\2{2}(.+?)\2(.*?)\2{2}'            # ***strongem*** or ***em*strong**
-STRONG_EM_RE = r'(\*|_)\2{2}(.+?)\2{2}(.*?)\2'            #  ***strong**em*
-SMART_EMPHASIS_RE = r'(?<!\w)(_)(?!_)(.+?)(?<!_)\2(?!\w)'  # _smart_emphasis_
-EMPHASIS_2_RE = r'(_)(.+?)\2'                 # _emphasis_
-LINK_RE = NOIMG + BRK + \
-r'''\(\s*(<.*?>|((?:(?:\(.*?\))|[^\(\)]))*?)\s*((['"])(.*?)\12\s*)?\)'''
+# `e=f()` or ``e=f("`")``
+BACKTICK_RE = r'(?<!\\)(`+)(.+?)(?<!`)\2(?!`)'
+
+# \<
+ESCAPE_RE = r'\\(.)'
+
+# *emphasis*
+EMPHASIS_RE = r'(\*)([^\*]+)\2'
+
+# **strong**
+STRONG_RE = r'(\*{2}|_{2})(.+?)\2'
+
+# ***strongem*** or ***em*strong**
+EM_STRONG_RE = r'(\*|_)\2{2}(.+?)\2(.*?)\2{2}'
+
+# ***strong**em*
+STRONG_EM_RE = r'(\*|_)\2{2}(.+?)\2{2}(.*?)\2'
+
+# _smart_emphasis_
+SMART_EMPHASIS_RE = r'(?<!\w)(_)(?!_)(.+?)(?<!_)\2(?!\w)'
+
+# _emphasis_
+EMPHASIS_2_RE = r'(_)(.+?)\2'
+
 # [text](url) or [text](<url>) or [text](url "title")
+LINK_RE = NOIMG + BRK + \
+    r'''\(\s*(<.*?>|((?:(?:\(.*?\))|[^\(\)]))*?)\s*((['"])(.*?)\12\s*)?\)'''
 
-IMAGE_LINK_RE = r'\!' + BRK + r'\s*\((<.*?>|([^")]+"[^"]*"|[^\)]*))\)'
 # ![alttxt](http://x.com/) or ![alttxt](<http://x.com/>)
-REFERENCE_RE = NOIMG + BRK+ r'\s?\[([^\]]*)\]'           # [Google][3]
-SHORT_REF_RE = NOIMG + r'\[([^\]]+)\]'                   # [Google]
-IMAGE_REFERENCE_RE = r'\!' + BRK + '\s?\[([^\]]*)\]' # ![alt text][2]
-NOT_STRONG_RE = r'((^| )(\*|_)( |$))'                        # stand-alone * or _
-AUTOLINK_RE = r'<((?:[Ff]|[Hh][Tt])[Tt][Pp][Ss]?://[^>]*)>' # <http://www.123.com>
-AUTOMAIL_RE = r'<([^> \!]*@[^> ]*)>'               # <me@example.com>
+IMAGE_LINK_RE = r'\!' + BRK + r'\s*\((<.*?>|([^")]+"[^"]*"|[^\)]*))\)'
 
-HTML_RE = r'(\<([a-zA-Z/][^\>]*?|\!--.*?--)\>)'               # <...>
-ENTITY_RE = r'(&[\#a-zA-Z0-9]*;)'               # &amp;
-LINE_BREAK_RE = r'  \n'                     # two spaces at end of line
+# [Google][3]
+REFERENCE_RE = NOIMG + BRK + r'\s?\[([^\]]*)\]'
+
+# [Google]
+SHORT_REF_RE = NOIMG + r'\[([^\]]+)\]'
+
+# ![alt text][2]
+IMAGE_REFERENCE_RE = r'\!' + BRK + '\s?\[([^\]]*)\]'
+
+# stand-alone * or _
+NOT_STRONG_RE = r'((^| )(\*|_)( |$))'
+
+# <http://www.123.com>
+AUTOLINK_RE = r'<((?:[Ff]|[Hh][Tt])[Tt][Pp][Ss]?://[^>]*)>'
+
+# <me@example.com>
+AUTOMAIL_RE = r'<([^> \!]*@[^> ]*)>'
+
+# <...>
+HTML_RE = r'(\<([a-zA-Z/][^\>]*?|\!--.*?--)\>)'
+
+# &amp;
+ENTITY_RE = r'(&[\#a-zA-Z0-9]*;)'
+
+# two spaces at end of line
+LINE_BREAK_RE = r'  \n'
 
 
 def dequote(string):
     """Remove quotes from around a string."""
-    if ( ( string.startswith('"') and string.endswith('"'))
-         or (string.startswith("'") and string.endswith("'")) ):
+    if ((string.startswith('"') and string.endswith('"')) or
+       (string.startswith("'") and string.endswith("'"))):
         return string[1:-1]
     else:
         return string
 
-ATTR_RE = re.compile("\{@([^\}]*)=([^\}]*)}") # {@id=123}
+
+ATTR_RE = re.compile("\{@([^\}]*)=([^\}]*)}")  # {@id=123}
+
 
 def handleAttributes(text, parent):
     """Set values of an element based on attribute definitions ({@id=123})."""
@@ -144,6 +183,7 @@ def handleAttributes(text, parent):
 The pattern classes
 -----------------------------------------------------------------------------
 """
+
 
 class Pattern(object):
     """Base class that inline patterns subclass. """
@@ -180,7 +220,7 @@ class Pattern(object):
         * m: A re match object containing a match of the pattern.
 
         """
-        pass #pragma: no cover
+        pass  # pragma: no cover
 
     def type(self):
         """ Return class name, to define pattern type """
@@ -190,20 +230,9 @@ class Pattern(object):
         """ Return unescaped text given text with an inline placeholder. """
         try:
             stash = self.markdown.treeprocessors['inline'].stashed_nodes
-        except KeyError: #pragma: no cover
+        except KeyError:  # pragma: no cover
             return text
-        def itertext(el): #pragma: no cover
-            ' Reimplement Element.itertext for older python versions '
-            tag = el.tag
-            if not isinstance(tag, util.string_type) and tag is not None:
-                return
-            if el.text:
-                yield el.text
-            for e in el:
-                for s in itertext(e):
-                    yield s
-                if e.tail:
-                    yield e.tail
+
         def get_stash(m):
             id = m.group(1)
             if id in stash:
@@ -239,7 +268,7 @@ class SimpleTagPattern(Pattern):
     of a Pattern.
 
     """
-    def __init__ (self, pattern, tag):
+    def __init__(self, pattern, tag):
         Pattern.__init__(self, pattern)
         self.tag = tag
 
@@ -251,13 +280,13 @@ class SimpleTagPattern(Pattern):
 
 class SubstituteTagPattern(SimpleTagPattern):
     """ Return an element of type `tag` with no children. """
-    def handleMatch (self, m):
+    def handleMatch(self, m):
         return util.etree.Element(self.tag)
 
 
 class BacktickPattern(Pattern):
     """ Return a `<code>` element containing the matching text. """
-    def __init__ (self, pattern):
+    def __init__(self, pattern):
         Pattern.__init__(self, pattern)
         self.tag = "code"
 
@@ -278,14 +307,14 @@ class DoubleTagPattern(SimpleTagPattern):
         el1 = util.etree.Element(tag1)
         el2 = util.etree.SubElement(el1, tag2)
         el2.text = m.group(3)
-        if len(m.groups())==5:
+        if len(m.groups()) == 5:
             el2.tail = m.group(4)
         return el1
 
 
 class HtmlPattern(Pattern):
     """ Store raw inline html and return a placeholder. """
-    def handleMatch (self, m):
+    def handleMatch(self, m):
         rawhtml = self.unescape(m.group(2))
         place_holder = self.markdown.htmlStash.store(rawhtml)
         return place_holder
@@ -294,8 +323,9 @@ class HtmlPattern(Pattern):
         """ Return unescaped text given text with an inline placeholder. """
         try:
             stash = self.markdown.treeprocessors['inline'].stashed_nodes
-        except KeyError: #pragma: no cover
+        except KeyError:  # pragma: no cover
             return text
+
         def get_stash(m):
             id = m.group(1)
             value = stash.get(id)
@@ -351,7 +381,7 @@ class LinkPattern(Pattern):
 
         try:
             scheme, netloc, path, params, query, fragment = url = urlparse(url)
-        except ValueError: #pragma: no cover
+        except ValueError:  # pragma: no cover
             # Bad url - so bad it couldn't be parsed.
             return ''
 
@@ -361,17 +391,19 @@ class LinkPattern(Pattern):
             # Not a known (allowed) scheme. Not safe.
             return ''
 
-        if netloc == '' and scheme not in locless_schemes: #pragma: no cover
+        if netloc == '' and scheme not in locless_schemes:  # pragma: no cover
             # This should not happen. Treat as suspect.
             return ''
 
         for part in url[2:]:
             if ":" in part:
-                # A colon in "path", "parameters", "query" or "fragment" is suspect.
+                # A colon in "path", "parameters", "query"
+                # or "fragment" is suspect.
                 return ''
 
         # Url passes all tests. Return url as-is.
         return urlunparse(url)
+
 
 class ImagePattern(LinkPattern):
     """ Return a img element from the given match. """
@@ -396,6 +428,7 @@ class ImagePattern(LinkPattern):
         el.set('alt', self.unescape(truealt))
         return el
 
+
 class ReferencePattern(LinkPattern):
     """ Match to a stored reference and return link element. """
 
@@ -413,7 +446,7 @@ class ReferencePattern(LinkPattern):
 
         # Clean up linebreaks in id
         id = self.NEWLINE_CLEANUP_RE.sub(' ', id)
-        if not id in self.markdown.references: # ignore undefined refs
+        if id not in self.markdown.references:  # ignore undefined refs
             return None
         href, title = self.markdown.references[id]
 
@@ -454,6 +487,7 @@ class AutolinkPattern(Pattern):
         el.text = util.AtomicString(m.group(2))
         return el
 
+
 class AutomailPattern(Pattern):
     """
     Return a mailto link Element given an automail link (`<foo@example.com>`).
@@ -480,4 +514,3 @@ class AutomailPattern(Pattern):
                           ord(letter) for letter in mailto])
         el.set('href', mailto)
         return el
-

--- a/markdown/odict.py
+++ b/markdown/odict.py
@@ -1,13 +1,13 @@
 from __future__ import unicode_literals
 from __future__ import absolute_import
 from . import util
-
 from copy import deepcopy
+
 
 class OrderedDict(dict):
     """
     A dictionary that keeps its keys in the order in which they're inserted.
-    
+
     Copied from Django's SortedDict with some modifications.
 
     """
@@ -82,11 +82,11 @@ class OrderedDict(dict):
         for key in self.keyOrder:
             yield self[key]
 
-    if util.PY3: #pragma: no cover
+    if util.PY3:  # pragma: no cover
         items = _iteritems
         keys = _iterkeys
         values = _itervalues
-    else: #pragma: no cover
+    else:  # pragma: no cover
         iteritems = _iteritems
         iterkeys = _iterkeys
         itervalues = _itervalues
@@ -133,7 +133,9 @@ class OrderedDict(dict):
         Replaces the normal dict.__repr__ with a version that returns the keys
         in their Ordered order.
         """
-        return '{%s}' % ', '.join(['%r: %r' % (k, v) for k, v in self._iteritems()])
+        return '{%s}' % ', '.join(
+            ['%r: %r' % (k, v) for k, v in self._iteritems()]
+        )
 
     def clear(self):
         super(OrderedDict, self).clear()

--- a/markdown/postprocessors.py
+++ b/markdown/postprocessors.py
@@ -42,7 +42,7 @@ class Postprocessor(util.Processor):
         (possibly modified) string.
 
         """
-        pass #pragma: no cover
+        pass  # pragma: no cover
 
 
 class RawHtmlPostprocessor(Postprocessor):
@@ -51,7 +51,7 @@ class RawHtmlPostprocessor(Postprocessor):
     def run(self, text):
         """ Iterate over html stash and restore "safe" html. """
         for i in range(self.markdown.htmlStash.html_counter):
-            html, safe  = self.markdown.htmlStash.rawHtmlBlocks[i]
+            html, safe = self.markdown.htmlStash.rawHtmlBlocks[i]
             if self.markdown.safeMode and not safe:
                 if str(self.markdown.safeMode).lower() == 'escape':
                     html = self.escape(html)
@@ -59,12 +59,16 @@ class RawHtmlPostprocessor(Postprocessor):
                     html = ''
                 else:
                     html = self.markdown.html_replacement_text
-            if self.isblocklevel(html) and (safe or not self.markdown.safeMode):
-                text = text.replace("<p>%s</p>" % 
-                            (self.markdown.htmlStash.get_placeholder(i)),
-                            html + "\n")
-            text =  text.replace(self.markdown.htmlStash.get_placeholder(i), 
-                                 html)
+            if (self.isblocklevel(html) and
+               (safe or not self.markdown.safeMode)):
+                text = text.replace(
+                    "<p>%s</p>" %
+                    (self.markdown.htmlStash.get_placeholder(i)),
+                    html + "\n"
+                )
+            text = text.replace(
+                self.markdown.htmlStash.get_placeholder(i), html
+            )
         return text
 
     def escape(self, html):
@@ -88,7 +92,7 @@ class AndSubstitutePostprocessor(Postprocessor):
     """ Restore valid entities """
 
     def run(self, text):
-        text =  text.replace(util.AMP_SUBSTITUTE, "&")
+        text = text.replace(util.AMP_SUBSTITUTE, "&")
         return text
 
 

--- a/markdown/preprocessors.py
+++ b/markdown/preprocessors.py
@@ -41,7 +41,7 @@ class Preprocessor(util.Processor):
         the (possibly modified) list of lines.
 
         """
-        pass #pragma: no cover
+        pass  # pragma: no cover
 
 
 class NormalizeWhitespace(Preprocessor):
@@ -61,13 +61,14 @@ class HtmlBlockPreprocessor(Preprocessor):
 
     right_tag_patterns = ["</%s>", "%s>"]
     attrs_pattern = r"""
-        \s+(?P<attr>[^>"'/= ]+)=(?P<q>['"])(?P<value>.*?)(?P=q)   # attr="value"
-        |                                                         # OR
-        \s+(?P<attr1>[^>"'/= ]+)=(?P<value1>[^> ]+)               # attr=value
-        |                                                         # OR
-        \s+(?P<attr2>[^>"'/= ]+)                                  # attr
+        \s+(?P<attr>[^>"'/= ]+)=(?P<q>['"])(?P<value>.*?)(?P=q) # attr="value"
+        |                                                       # OR
+        \s+(?P<attr1>[^>"'/= ]+)=(?P<value1>[^> ]+)             # attr=value
+        |                                                       # OR
+        \s+(?P<attr2>[^>"'/= ]+)                                # attr
         """
-    left_tag_pattern = r'^\<(?P<tag>[^> ]+)(?P<attrs>(%s)*)\s*\/?\>?' % attrs_pattern
+    left_tag_pattern = r'^\<(?P<tag>[^> ]+)(?P<attrs>(%s)*)\s*\/?\>?' % \
+                       attrs_pattern
     attrs_re = re.compile(attrs_pattern, re.VERBOSE)
     left_tag_re = re.compile(left_tag_pattern, re.VERBOSE)
     markdown_in_raw = False
@@ -87,7 +88,9 @@ class HtmlBlockPreprocessor(Preprocessor):
                             attrs[ma.group('attr').strip()] = ""
                     elif ma.group('attr1'):
                         if ma.group('value1'):
-                            attrs[ma.group('attr1').strip()] = ma.group('value1')
+                            attrs[ma.group('attr1').strip()] = ma.group(
+                                'value1'
+                            )
                         else:
                             attrs[ma.group('attr1').strip()] = ""
                     elif ma.group('attr2'):
@@ -118,20 +121,21 @@ class HtmlBlockPreprocessor(Preprocessor):
     def _get_right_tag(self, left_tag, left_index, block):
         for p in self.right_tag_patterns:
             tag = p % left_tag
-            i = self._recursive_tagfind("<%s" % left_tag, tag, left_index, block)
+            i = self._recursive_tagfind(
+                "<%s" % left_tag, tag, left_index, block
+            )
             if i > 2:
                 return tag.lstrip("<").rstrip(">"), i
         return block.rstrip()[-left_index:-1].lower(), len(block)
 
     def _equal_tags(self, left_tag, right_tag):
-        if left_tag[0] in ['?', '@', '%']: # handle PHP, etc.
+        if left_tag[0] in ['?', '@', '%']:  # handle PHP, etc.
             return True
         if ("/" + left_tag) == right_tag:
             return True
         if (right_tag == "--" and left_tag == "--"):
             return True
-        elif left_tag == right_tag[1:] \
-            and right_tag[0] == "/":
+        elif left_tag == right_tag[1:] and right_tag[0] == "/":
             return True
         else:
             return False
@@ -188,7 +192,7 @@ class HtmlBlockPreprocessor(Preprocessor):
         items = []
         left_tag = ''
         right_tag = ''
-        in_tag = False # flag
+        in_tag = False  # flag
 
         while text:
             block = text[0]
@@ -204,7 +208,7 @@ class HtmlBlockPreprocessor(Preprocessor):
 
                     if block[1:4] == "!--":
                         # is a comment block
-                        left_tag, left_index, attrs  = "--", 2, {}
+                        left_tag, left_index, attrs = "--", 2, {}
                     else:
                         left_tag, left_index, attrs = self._get_left_tag(block)
                     right_tag, data_index = self._get_right_tag(left_tag,
@@ -212,14 +216,11 @@ class HtmlBlockPreprocessor(Preprocessor):
                                                                 block)
                     # keep checking conditions below and maybe just append
 
-                    if data_index < len(block) \
-                        and (util.isBlockLevel(left_tag)
-                        or left_tag == '--'):
+                    if data_index < len(block) and (util.isBlockLevel(left_tag) or left_tag == '--'):
                         text.insert(0, block[data_index:])
                         block = block[:data_index]
 
-                    if not (util.isBlockLevel(left_tag) \
-                        or block[1] in ["!", "?", "@", "%"]):
+                    if not (util.isBlockLevel(left_tag) or block[1] in ["!", "?", "@", "%"]):
                         new_blocks.append(block)
                         continue
 
@@ -240,14 +241,14 @@ class HtmlBlockPreprocessor(Preprocessor):
                         continue
                     else:
                         # if is block level tag and is not complete
-                        if  (not self._equal_tags(left_tag, right_tag)) and \
-                            (util.isBlockLevel(left_tag) or left_tag == "--"):
+                        if (not self._equal_tags(left_tag, right_tag)) and \
+                           (util.isBlockLevel(left_tag) or left_tag == "--"):
                             items.append(block.strip())
                             in_tag = True
                         else:
                             new_blocks.append(
-                            self.markdown.htmlStash.store(block.strip()))
-
+                                self.markdown.htmlStash.store(block.strip())
+                            )
                         continue
 
                 else:
@@ -317,11 +318,13 @@ class ReferencePreprocessor(Preprocessor):
     """ Remove reference definitions from text and store for later use. """
 
     TITLE = r'[ ]*(\"(.*)\"|\'(.*)\'|\((.*)\))[ ]*'
-    RE = re.compile(r'^[ ]{0,3}\[([^\]]*)\]:\s*([^ ]*)[ ]*(%s)?$' % TITLE, re.DOTALL)
+    RE = re.compile(
+        r'^[ ]{0,3}\[([^\]]*)\]:\s*([^ ]*)[ ]*(%s)?$' % TITLE, re.DOTALL
+    )
     TITLE_RE = re.compile(r'^%s$' % TITLE)
 
-    def run (self, lines):
-        new_text = [];
+    def run(self, lines):
+        new_text = []
         while lines:
             line = lines.pop(0)
             m = self.RE.match(line)
@@ -339,4 +342,4 @@ class ReferencePreprocessor(Preprocessor):
             else:
                 new_text.append(line)
 
-        return new_text #+ "\n"
+        return new_text  # + "\n"

--- a/markdown/serializers.py
+++ b/markdown/serializers.py
@@ -42,9 +42,9 @@ from __future__ import unicode_literals
 from . import util
 ElementTree = util.etree.ElementTree
 QName = util.etree.QName
-if hasattr(util.etree, 'test_comment'): #pragma: no cover
+if hasattr(util.etree, 'test_comment'):  # pragma: no cover
     Comment = util.etree.test_comment
-else: #pragma: no cover
+else:  # pragma: no cover
     Comment = util.etree.Comment
 PI = util.etree.PI
 ProcessingInstruction = util.etree.ProcessingInstruction
@@ -56,7 +56,7 @@ HTML_EMPTY = ("area", "base", "basefont", "br", "col", "frame", "hr",
 
 try:
     HTML_EMPTY = set(HTML_EMPTY)
-except NameError: #pragma: no cover
+except NameError:  # pragma: no cover
     pass
 
 _namespace_map = {
@@ -73,16 +73,18 @@ _namespace_map = {
 }
 
 
-def _raise_serialization_error(text): #pragma: no cover
+def _raise_serialization_error(text):  # pragma: no cover
     raise TypeError(
         "cannot serialize %r (type %s)" % (text, type(text).__name__)
         )
 
+
 def _encode(text, encoding):
     try:
         return text.encode(encoding, "xmlcharrefreplace")
-    except (TypeError, AttributeError): #pragma: no cover
+    except (TypeError, AttributeError):  # pragma: no cover
         _raise_serialization_error(text)
+
 
 def _escape_cdata(text):
     # escape character data
@@ -97,7 +99,7 @@ def _escape_cdata(text):
         if ">" in text:
             text = text.replace(">", "&gt;")
         return text
-    except (TypeError, AttributeError): #pragma: no cover
+    except (TypeError, AttributeError):  # pragma: no cover
         _raise_serialization_error(text)
 
 
@@ -115,8 +117,9 @@ def _escape_attrib(text):
         if "\n" in text:
             text = text.replace("\n", "&#10;")
         return text
-    except (TypeError, AttributeError): #pragma: no cover
+    except (TypeError, AttributeError):  # pragma: no cover
         _raise_serialization_error(text)
+
 
 def _escape_attrib_html(text):
     # escape attribute value
@@ -130,7 +133,7 @@ def _escape_attrib_html(text):
         if "\"" in text:
             text = text.replace("\"", "&quot;")
         return text
-    except (TypeError, AttributeError): #pragma: no cover
+    except (TypeError, AttributeError):  # pragma: no cover
         _raise_serialization_error(text)
 
 
@@ -152,7 +155,7 @@ def _serialize_html(write, elem, qnames, namespaces, format):
             write("<" + tag)
             items = elem.items()
             if items or namespaces:
-                items = sorted(items) # lexical order
+                items = sorted(items)  # lexical order
                 for k, v in items:
                     if isinstance(k, QName):
                         k = k.text
@@ -167,7 +170,7 @@ def _serialize_html(write, elem, qnames, namespaces, format):
                         write(" %s=\"%s\"" % (qnames[k], v))
                 if namespaces:
                     items = namespaces.items()
-                    items.sort(key=lambda x: x[1]) # sort on prefix
+                    items.sort(key=lambda x: x[1])  # sort on prefix
                     for v, k in items:
                         if k:
                             k = ":" + k
@@ -187,6 +190,7 @@ def _serialize_html(write, elem, qnames, namespaces, format):
                     write("</" + tag + ">")
     if elem.tail:
         write(_escape_cdata(elem.tail))
+
 
 def _write_html(root,
                 encoding=None,
@@ -232,7 +236,7 @@ def _namespaces(elem, default_namespace=None):
                 if prefix:
                     qnames[qname] = "%s:%s" % (prefix, tag)
                 else:
-                    qnames[qname] = tag # default element
+                    qnames[qname] = tag  # default element
             else:
                 if default_namespace:
                     raise ValueError(
@@ -240,15 +244,11 @@ def _namespaces(elem, default_namespace=None):
                         "default_namespace option"
                         )
                 qnames[qname] = qname
-        except TypeError: #pragma: no cover
+        except TypeError:  # pragma: no cover
             _raise_serialization_error(qname)
 
     # populate qname and namespaces table
-    try:
-        iterate = elem.iter
-    except AttributeError:
-        iterate = elem.getiterator # cET compatibility
-    for elem in iterate():
+    for elem in util.iterate(elem):
         tag = elem.tag
         if isinstance(tag, QName) and tag.text not in qnames:
             add_qname(tag.text)
@@ -269,8 +269,10 @@ def _namespaces(elem, default_namespace=None):
             add_qname(text.text)
     return qnames, namespaces
 
+
 def to_html_string(element):
     return _write_html(ElementTree(element).getroot(), format="html")
+
 
 def to_xhtml_string(element):
     return _write_html(ElementTree(element).getroot(), format="xhtml")

--- a/markdown/treeprocessors.py
+++ b/markdown/treeprocessors.py
@@ -38,7 +38,7 @@ class Treeprocessor(util.Processor):
         object, and the existing root ElementTree will be replaced, or it can
         modify the current tree and return None.
         """
-        pass #pragma: no cover
+        pass  # pragma: no cover
 
 
 class InlineProcessor(Treeprocessor):
@@ -183,15 +183,17 @@ class InlineProcessor(Treeprocessor):
                         text = data[strartIndex:index]
                         linkText(text)
 
-                    if not isString(node): # it's Element
+                    if not isString(node):  # it's Element
                         for child in [node] + list(node):
                             if child.tail:
                                 if child.tail.strip():
-                                    self.__processElementText(node, child, False)
+                                    self.__processElementText(
+                                        node, child, False
+                                    )
                             if child.text:
                                 if child.text.strip():
                                     self.__processElementText(child, child)
-                    else: # it's just a string
+                    else:  # it's just a string
                         linkText(node)
                         strartIndex = phEndIndex
                         continue
@@ -199,7 +201,7 @@ class InlineProcessor(Treeprocessor):
                     strartIndex = phEndIndex
                     result.append(node)
 
-                else: # wrong placeholder
+                else:  # wrong placeholder
                     end = index + len(self.__placeholder_prefix)
                     linkText(data[strartIndex:end])
                     strartIndex = end
@@ -245,11 +247,13 @@ class InlineProcessor(Treeprocessor):
                 for child in [node] + list(node):
                     if not isString(node):
                         if child.text:
-                            child.text = self.__handleInline(child.text,
-                                                            patternIndex + 1)
+                            child.text = self.__handleInline(
+                                child.text, patternIndex + 1
+                            )
                         if child.tail:
-                            child.tail = self.__handleInline(child.tail,
-                                                            patternIndex)
+                            child.tail = self.__handleInline(
+                                child.tail, patternIndex
+                            )
 
         placeholder = self.__stashNode(node, pattern.type())
 
@@ -262,8 +266,8 @@ class InlineProcessor(Treeprocessor):
 
         Iterate over ElementTree, find elements with inline tag, apply inline
         patterns and append newly created Elements to tree.  If you don't
-        want to process your data with inline paterns, instead of normal string,
-        use subclass AtomicString:
+        want to process your data with inline paterns, instead of normal
+        string, use subclass AtomicString:
 
             node.text = markdown.AtomicString("This will not be processed.")
 
@@ -282,11 +286,14 @@ class InlineProcessor(Treeprocessor):
             currElement = stack.pop()
             insertQueue = []
             for child in currElement:
-                if child.text and not isinstance(child.text, util.AtomicString):
+                if child.text and not isinstance(
+                    child.text, util.AtomicString
+                ):
                     text = child.text
                     child.text = None
-                    lst = self.__processPlaceholders(self.__handleInline(
-                                                    text), child)
+                    lst = self.__processPlaceholders(
+                        self.__handleInline(text), child
+                    )
                     stack += lst
                     insertQueue.append((child, lst))
                 if child.tail:
@@ -306,21 +313,21 @@ class InlineProcessor(Treeprocessor):
             for element, lst in insertQueue:
                 if self.markdown.enable_attributes:
                     if element.text and isString(element.text):
-                        element.text = \
-                            inlinepatterns.handleAttributes(element.text,
-                                                                    element)
+                        element.text = inlinepatterns.handleAttributes(
+                            element.text, element
+                        )
                 i = 0
                 for newChild in lst:
                     if self.markdown.enable_attributes:
                         # Processing attributes
                         if newChild.tail and isString(newChild.tail):
-                            newChild.tail = \
-                                inlinepatterns.handleAttributes(newChild.tail,
-                                                                    element)
+                            newChild.tail = inlinepatterns.handleAttributes(
+                                newChild.tail, element
+                            )
                         if newChild.text and isString(newChild.text):
-                            newChild.text = \
-                                inlinepatterns.handleAttributes(newChild.text,
-                                                                    newChild)
+                            newChild.text = inlinepatterns.handleAttributes(
+                                newChild.text, newChild
+                            )
                     element.insert(i, newChild)
                     i += 1
         return tree

--- a/markdown/util.py
+++ b/markdown/util.py
@@ -10,14 +10,14 @@ Python 3 Stuff
 """
 PY3 = sys.version_info[0] == 3
 
-if PY3: #pragma: no cover
+if PY3:  # pragma: no cover
     string_type = str
     text_type = str
     int2str = chr
-else: #pragma: no cover
-    string_type = basestring
-    text_type = unicode
-    int2str = unichr
+else:  # pragma: no cover
+    string_type = basestring   # noqa
+    text_type = unicode        # noqa
+    int2str = unichr           # noqa
 
 
 """
@@ -25,12 +25,16 @@ Constants you might want to modify
 -----------------------------------------------------------------------------
 """
 
-BLOCK_LEVEL_ELEMENTS = re.compile("^(p|div|h[1-6]|blockquote|pre|table|dl|ol|ul"
-                                  "|script|noscript|form|fieldset|iframe|math"
-                                  "|hr|hr/|style|li|dt|dd|thead|tbody"
-                                  "|tr|th|td|section|footer|header|group|figure"
-                                  "|figcaption|aside|article|canvas|output"
-                                  "|progress|video|nav)$", re.IGNORECASE)
+
+BLOCK_LEVEL_ELEMENTS = re.compile(
+    "^(p|div|h[1-6]|blockquote|pre|table|dl|ol|ul"
+    "|script|noscript|form|fieldset|iframe|math"
+    "|hr|hr/|style|li|dt|dd|thead|tbody"
+    "|tr|th|td|section|footer|header|group|figure"
+    "|figcaption|aside|article|canvas|output"
+    "|progress|video|nav)$",
+    re.IGNORECASE
+)
 # Placeholders
 STX = '\u0002'  # Use STX ("Start of text") for start-of-placeholder
 ETX = '\u0003'  # Use ETX ("End of text") for end-of-placeholder
@@ -48,17 +52,18 @@ Constants you probably do not need to change
 -----------------------------------------------------------------------------
 """
 
-RTL_BIDI_RANGES = ( ('\u0590', '\u07FF'),
-                     # Hebrew (0590-05FF), Arabic (0600-06FF),
-                     # Syriac (0700-074F), Arabic supplement (0750-077F),
-                     # Thaana (0780-07BF), Nko (07C0-07FF).
-                    ('\u2D30', '\u2D7F'), # Tifinagh
-                    )
+RTL_BIDI_RANGES = (
+    ('\u0590', '\u07FF'),
+    # Hebrew (0590-05FF), Arabic (0600-06FF),
+    # Syriac (0700-074F), Arabic supplement (0750-077F),
+    # Thaana (0780-07BF), Nko (07C0-07FF).
+    ('\u2D30', '\u2D7F')  # Tifinagh
+)
 
 # Extensions should use "markdown.util.etree" instead of "etree" (or do `from
 # markdown.util import etree`).  Do not import it by yourself.
 
-try: #pragma: no cover
+try:  # pragma: no cover
     # Is the C implementation of ElementTree available?
     import xml.etree.cElementTree as etree
     from xml.etree.ElementTree import Comment
@@ -66,12 +71,38 @@ try: #pragma: no cover
     etree.test_comment = Comment
     if etree.VERSION < "1.0.5":
         raise RuntimeError("cElementTree version 1.0.5 or higher is required.")
-except (ImportError, RuntimeError): #pragma: no cover
+except (ImportError, RuntimeError):  # pragma: no cover
     # Use the Python implementation of ElementTree?
     import xml.etree.ElementTree as etree
     if etree.VERSION < "1.1":
         raise RuntimeError("ElementTree version 1.1 or higher is required")
 
+
+def iterate(elem, tag=None):
+    if hasattr(elem, 'iter'):
+        # Python 2.7+
+        return elem.iter(tag)
+    return elem.getiterator(tag)
+
+
+def itertext(elem, tag=None):
+    if hasattr(elem, 'itertext'):
+        # Python 2.7+
+        return elem.iter(tag)
+    return elem.getiterator(tag)
+
+
+def itertext(elem):
+    tag = elem.tag
+    if not isinstance(tag, string_type) and tag is not None:
+        return
+    if elem.text:
+        yield elem.text
+    for e in elem:
+        for s in itertext(e):
+            yield s
+        if e.tail:
+            yield e.tail
 
 """
 AUXILIARY GLOBAL FUNCTIONS
@@ -86,14 +117,15 @@ def isBlockLevel(tag):
     # Some ElementTree tags are not strings, so return False.
     return False
 
+
 def parseBoolValue(value, fail_on_errors=True, preserve_none=False):
     """Parses a string representing bool value. If parsing was successful,
-       returns True or False. If preserve_none=True, returns True, False, 
-       or None. If parsing was not successful, raises  ValueError, or, if 
+       returns True or False. If preserve_none=True, returns True, False,
+       or None. If parsing was not successful, raises  ValueError, or, if
        fail_on_errors=False, returns None."""
     if not isinstance(value, string_type):
         if preserve_none and value is None:
-            return  value
+            return value
         return bool(value)
     elif preserve_none and value.lower() == 'none':
         return None
@@ -104,10 +136,12 @@ def parseBoolValue(value, fail_on_errors=True, preserve_none=False):
     elif fail_on_errors:
         raise ValueError('Cannot parse bool value: %r' % value)
 
+
 """
 MISC AUXILIARY CLASSES
 =============================================================================
 """
+
 
 class AtomicString(text_type):
     """A string which should not be further processed."""

--- a/tests/test.md
+++ b/tests/test.md
@@ -22,7 +22,6 @@
         - insert
         - progressbar
         - toc
-        - headerid
         - smarty
         - meta
         - wikilinks
@@ -32,7 +31,7 @@
 test: This tests the meta extension
 title: This title will be overridden by YAML
 
-!!! hint "Recommended Extentions for Testing"
+!!! hint "Recommended Extensions for Testing"
     This is mainly used to test the Python Markdown parser.
 
     - extra
@@ -40,7 +39,6 @@ title: This title will be overridden by YAML
     - insert
     - progressbar
     - toc
-    - headerid
     - smarty
     - meta
     - wikilinks
@@ -234,7 +232,7 @@ This is a link "https://github.com/revolunet/sublimetext-markdown-preview/".
 With this link (https://github.com/revolunet/sublimetext-markdown-preview/), it still works.
 
 ## Abbreviation
-Abreviations source are found in a separate markdown file specified in frontmatter.
+Abbreviations source are found in a separate markdown file specified in frontmatter.
 ```
 The HTML specification 
 is maintained by the W3C.


### PR DESCRIPTION
### Upgrade Markdown

- Upgrade to Python Markdown 2.6.2 via https://github.com/EnTeQuAk/python-markdown-py26-support  fork (makes hand merging way easier as this fork as re-added in PY26 support).
- Upgrade 3rd party plugins to latest version and modify to work with
https://github.com/EnTeQuAk/python-markdown-py26-support fork and the Sublime Text environment.
- Update readme with proper doc links which satisfies #281.

### Notes

- 2.6 Python Markdown branch appears to moving in a bug fix only state as Python Markdown 3 will have many backwards compatibility breaks.  I probably won't try to update Markdown Preview past 2.6 releases moving forward as I suspect there will be much refactoring that will have to be done for 3.0.  But 2.6 moving to a bug fix state means that most of the 2.6 releases should be pretty easy to merge in from now on.
- Python Markdown has deprecated `headerid` as functionality is now pushed into `toc`.  This is why we remove `headerid` from the default extensions in the settings.
- `enable_pygments` option now only has an effect if using `enable_highlight`.  This is just like how `guess_language` works.  If defining `codehilite` manually, you should use the `use_pygments` options or `guess_language` option that is built into the `codehilite` plugin officially.  Personally, I feel `enable_pygments`, `guess_language`, and `enable_highlight` should be deprecated in favor of the manual configuration method as it would reduce code and be consistent with the way all other plugins are configured, but I feel this should be discussed and/or completed at another time.