### PR TITLE
Add clipboard_path as target

### DIFF
--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -7,6 +7,13 @@
         }
     },
     {
+        "caption": "Markdown Preview: Copy HTML file path to Clipboard",
+        "command": "markdown_preview_select",
+        "args": {
+            "target": "clipboard_path"
+        }
+    },
+    {
         "caption": "Markdown Preview: Export HTML in Sublime Text",
         "command": "markdown_preview_select",
         "args": {

--- a/MarkdownPreview.py
+++ b/MarkdownPreview.py
@@ -1176,9 +1176,9 @@ class MarkdownPreviewCommand(sublime_plugin.TextCommand):
             # Fallback to Python Markdown
             compiler = MarkdownCompiler()
 
-        html, body = compiler.run(self.view, preview=(target in ['disk', 'browser']))
+        html, body = compiler.run(self.view, preview=(target in ['disk', 'browser', 'clipboard_path']))
 
-        if target in ['disk', 'browser']:
+        if target in ['disk', 'browser', 'clipboard_path']:
             # do not use LiveReload unless autoreload is enabled
             if settings.get('enable_autoreload', True):
                 # check if LiveReload ST2 extension installed and add its script to the resulting HTML
@@ -1193,6 +1193,8 @@ class MarkdownPreviewCommand(sublime_plugin.TextCommand):
             # now opens in browser if needed
             if target == 'browser':
                 self.__class__.open_in_browser(tmp_fullpath, settings.get('browser', 'default'))
+            elif target == 'clipboard_path':
+                sublime.set_clipboard(tmp_fullpath)
         elif target == 'sublime':
             # create a new buffer and paste the output HTML
             embed_css = settings.get('embed_css_for_sublime_output', True)

--- a/MarkdownPreview.sublime-settings
+++ b/MarkdownPreview.sublime-settings
@@ -33,6 +33,7 @@
         build - The default build behavior.
         browser - Preview the file in your browser.
         clipboard - Copy the HTML output to the clipboard.
+        clipboard_path - Copy the HTML file path to the clipboard.
         sublime - Export the HTML to a Sublime tab.
         save - Run the normal save command that outputs to the source directory.
             It will also prompt for "save as" if the file does not exit on disk.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ For all Sublime Text 2/3 users we recommend install via [Package Control][3].
  - optionally select some of your markdown for conversion
  - use <kbd>cmd</kbd>+<kbd>shift</kbd>+<kbd>P</kbd> then `Markdown Preview` to show the follow commands (you will be prompted to select which parser you prefer):
 	- Markdown Preview: Preview in Browser
+    - Markdown Preview: Copy HTML file path to Clipboard
 	- Markdown Preview: Export HTML in Sublime Text
 	- Markdown Preview: Copy to Clipboard
 	- Markdown Preview: Open Markdown Cheat sheet

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For all Sublime Text 2/3 users we recommend install via [Package Control][3].
  - optionally select some of your markdown for conversion
  - use <kbd>cmd</kbd>+<kbd>shift</kbd>+<kbd>P</kbd> then `Markdown Preview` to show the follow commands (you will be prompted to select which parser you prefer):
 	- Markdown Preview: Preview in Browser
-    - Markdown Preview: Copy HTML file path to Clipboard
+	- Markdown Preview: Copy HTML file path to Clipboard
 	- Markdown Preview: Export HTML in Sublime Text
 	- Markdown Preview: Copy to Clipboard
 	- Markdown Preview: Open Markdown Cheat sheet


### PR DESCRIPTION
This patch is not essential although, I believe it might help few people who prefer to get file path of exported HTML file instead of opening it in their browsers.

An alternative target would be `output_path` which is same as `clipboard_path` except it outputs the file path to sublime console instead of copying it to the clipboard.
