### PR TITLE
Proper error message when GitHub's API rate limit is reached

### DIFF
--- a/MarkdownPreview.py
+++ b/MarkdownPreview.py
@@ -920,18 +920,18 @@ class GithubCompiler(Compiler):
             markdown_html = urlopen(request).read().decode('utf-8')
         except HTTPError as e:
             if e.code == 401:
-                error_message = 'GitHub API authentication failed. Please check your OAuth token.\r\n\r\n'
+                error_message = 'GitHub API authentication failed. Please check your OAuth token.\n\n'
                 sublime.error_message(error_message + get_github_response_from_exception(e))
             elif e.code == 403: # Forbidden
-                message = "It seems like you have exceeded GitHub\'s API rate limit.\r\n\r\n"
+                message = "It seems like you have exceeded GitHub\'s API rate limit.\n\n"
                 message += "To continue using GitHub's markdown format with this package, log in to "
                 message += "GitHub, then go to Settings > Personal access tokens > Generate new token, "
                 message +=" copy the token's value, and paste it in this package's user settings under the key "
-                message += "'github_oauth_token'. Example:\r\n\r\n"
-                message += "{\r\n\t\"github_oauth_token\": \"xxxx....\"\r\n}\r\n\r\n"""
+                message += "'github_oauth_token'. Example:\n\n"
+                message += "{\n\t\"github_oauth_token\": \"xxxx....\"\n}\n\n"""
                 sublime.error_message(message + get_github_response_from_exception(e))
             else:
-                error_message = 'GitHub API responded in an unfriendly way.\r\n\r\n'
+                error_message = 'GitHub API responded in an unfriendly way.\n\n'
                 sublime.error_message(error_message + get_github_response_from_exception(e))
         except URLError:
             # Maybe this is a Linux-install of ST which doesn't bundle with SSL support
@@ -941,7 +941,7 @@ class GithubCompiler(Compiler):
             e = sys.exc_info()[1]
             print(e)
             traceback.print_exc()
-            sublime.error_message('Cannot use GitHub\'s API to convert Markdown. Please check your settings.\r\n\r\n' + get_github_response_from_exception(e))
+            sublime.error_message('Cannot use GitHub\'s API to convert Markdown. Please check your settings.\n\n' + get_github_response_from_exception(e))
         else:
             sublime.status_message('converted markdown with github API successfully')
 

--- a/MarkdownPreview.py
+++ b/MarkdownPreview.py
@@ -904,6 +904,10 @@ class GithubCompiler(Compiler):
         }
         data = json.dumps(data).encode('utf-8')
 
+        def get_github_response_from_exception(e):
+            body = json.loads(e.read().decode('utf-8'))
+            return 'GitHub\'s original response: (HTTP Status Code %s) "%s"' % (e.code, body['message'])
+
         try:
             headers = {
                 'Content-Type': 'application/json'
@@ -914,12 +918,21 @@ class GithubCompiler(Compiler):
             sublime.status_message(url)
             request = Request(url, data, headers)
             markdown_html = urlopen(request).read().decode('utf-8')
-        except HTTPError:
-            e = sys.exc_info()[1]
+        except HTTPError as e:
             if e.code == 401:
-                sublime.error_message('github API auth failed. Please check your OAuth token.')
+                error_message = 'GitHub API authentication failed. Please check your OAuth token.\r\n\r\n'
+                sublime.error_message(error_message + get_github_response_from_exception(e))
+            elif e.code == 403: # Forbidden
+                message = "It seems like you have exceeded GitHub\'s API rate limit.\r\n\r\n"
+                message += "To continue using GitHub's markdown format with this package, log in to "
+                message += "GitHub, then go to Settings > Personal access tokens > Generate new token, "
+                message +=" copy the token's value, and paste it in this package's user settings under the key "
+                message += "'github_oauth_token'. Example:\r\n\r\n"
+                message += "{\r\n\t\"github_oauth_token\": \"xxxx....\"\r\n}\r\n\r\n"""
+                sublime.error_message(message + get_github_response_from_exception(e))
             else:
-                sublime.error_message('github API responded in an unfriendly way :/')
+                error_message = 'GitHub API responded in an unfriendly way.\r\n\r\n'
+                sublime.error_message(error_message + get_github_response_from_exception(e))
         except URLError:
             # Maybe this is a Linux-install of ST which doesn't bundle with SSL support
             # So let's try wrapping curl instead
@@ -928,7 +941,7 @@ class GithubCompiler(Compiler):
             e = sys.exc_info()[1]
             print(e)
             traceback.print_exc()
-            sublime.error_message('cannot use github API to convert markdown. Please check your settings.')
+            sublime.error_message('Cannot use GitHub\'s API to convert Markdown. Please check your settings.\r\n\r\n' + get_github_response_from_exception(e))
         else:
             sublime.status_message('converted markdown with github API successfully')
 


### PR DESCRIPTION
Now, instead of the old `github API responded in an unfriendly way :/` error message displayed when GitHub's API rate limit was exceeded, a more informational message is displayed:

> It seems like you have exceeded GitHub's API rate limit.
> 
> To continue using GitHub's markdown format with this package, log in to GitHub, then go to Settings > Personal access tokens > Generate new token, copy the token's value, and paste it in this package's user settings under the key  'github_oauth_token'. Example:
> 
> {
>     "github_oauth_token": "xxxx....""
> }
> 
> GitHub's original response: (HTTP Status Code 403) "API rate limit exceeded for IPADDRESS (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)"

![markdownpreviewgithubapierror](https://cloud.githubusercontent.com/assets/7514993/19562464/6c54aff2-96aa-11e6-8c27-75855ab596f6.PNG)

Also, some other messages for GitHub's API request errors were enhanced aswell.
