### PR TITLE
Remember last selected parser

### DIFF
--- a/MarkdownPreview.py
+++ b/MarkdownPreview.py
@@ -1110,6 +1110,8 @@ class MarkdownCompiler(Compiler):
 
 
 class MarkdownPreviewSelectCommand(sublime_plugin.TextCommand):
+    selected = 0
+
     def run(self, edit, target='browser'):
 
         settings = sublime.load_settings("MarkdownPreview.sublime-settings")
@@ -1145,10 +1147,13 @@ class MarkdownPreviewSelectCommand(sublime_plugin.TextCommand):
                     }
                 )
             else:
-                window.show_quick_panel(self.user_parsers, self.run_command)
+                window.show_quick_panel(
+                    self.user_parsers, self.run_command, 0, self.selected
+                )
 
     def run_command(self, value):
         if value > -1:
+            self.selected = value
             self.view.run_command(
                 "markdown_preview",
                 {


### PR DESCRIPTION
Remember (temporary) the parser chosen from quick panel. Next time user runs "markdown_preview_select", previous parser will be selected by default. This is useful when you run the command multiple times during the session and github is not your parser of choice.