### PR TITLE
Switching `enable_autoreload` default to `false`

### DIFF
--- a/MarkdownPreview.sublime-settings
+++ b/MarkdownPreview.sublime-settings
@@ -193,7 +193,7 @@
     /*
         Enable or not whether parsed files will be auto-reloaded on save
     */
-    "enable_autoreload": true,
+    "enable_autoreload": false,
 
     /*
         Sets the supported filetypes for auto-reload on save


### PR DESCRIPTION
Having `enable_autoreload` (which re-parses the doc each time it's saved) on by default causes confusing behaviour. See.. https://github.com/revolunet/sublimetext-markdown-preview/issues/240