### PR TITLE
Fix #414: updates links to python markdown

### DIFF
--- a/MarkdownPreview.sublime-settings
+++ b/MarkdownPreview.sublime-settings
@@ -88,7 +88,7 @@
         List of enabled extensions of the selected markdown parser.
 
         You can get the full list of extensions at:
-            * The python markdown parser, the `markdown`: http://pythonhosted.org/Markdown/extensions/index.html
+            * The python markdown parser, the `markdown`: https://python-markdown.github.io/extensions
 
 
         default - use the default set of extensions, see table later.

--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ If you add the codehilite extension manually in the enabled extensions, you can 
 * Inline the CSS: `codehilite(noclasses=True)` (True|False).
 * Use multiple: `codehilite(linenums=True, pygments_style-emacs)`.
 
-See [codehilte page](https://pythonhosted.org/Markdown/extensions/code_hilite.html) for more info.
+See [codehilte page](https://python-markdown.github.io/extensions/code_hilite) for more info.
 
 ### Meta Data Support
-When the `meta` extension is enabled (https://pythonhosted.org/Markdown/extensions/meta_data.html), the results will be written to the HTML head in the form `<meta name="key" content="value1,value2">`.  `title` is the one exception, and its content will be written to the title tag in the HTML head.
+When the `meta` extension is enabled (https://python-markdown.github.io/extensions/meta_data), the results will be written to the HTML head in the form `<meta name="key" content="value1,value2">`.  `title` is the one exception, and its content will be written to the title tag in the HTML head.
 
 ### YAML Frontmatter Support
 YAML frontmatter can be stripped out and read when `strip_yaml_front_matter` is set to  `true` in the settings file.  In general the, the fronmatter is handled the same as [meta data](#meta-data-support), but if both exist in a file, the YAML keys will override the `meta` extension keys.  There are a few special keys names that won't be handled as html meta data.

--- a/markdown/README.md
+++ b/markdown/README.md
@@ -12,10 +12,10 @@ though there are a few known issues. See [Features][] for information
 on what exactly is supported and what is not. Additional features are 
 supported by the [Available Extensions][].
 
-[Python-Markdown]: http://packages.python.org/Markdown/
+[Python-Markdown]: https://python-markdown.github.io/
 [Markdown]: http://daringfireball.net/projects/markdown/
-[Features]: http://packages.python.org/Markdown/index.html#Features
-[Available Extensions]: http://packages.python.org/Markdown/extensions/index.html
+[Features]: https://python-markdown.github.io/#features
+[Available Extensions]: https://python-markdown.github.io/extensions
 
 
 Documentation
@@ -23,7 +23,7 @@ Documentation
 
 Installation and usage documentation is available in the `docs/` directory
 of the distribution and on the project website at 
-<http://packages.python.org/Markdown/>.
+<https://python-markdown.github.io>.
 
 Support
 -------

--- a/markdown/__init__.py
+++ b/markdown/__init__.py
@@ -10,7 +10,7 @@ called from the command line.
     import markdown
     html = markdown.markdown(your_text_string)
 
-See <https://pythonhosted.org/Markdown/> for more
+See <https://python-markdown.github.io/> for more
 information and instructions on how to extend the functionality of
 Python Markdown.  Read that before you try modifying this file.
 

--- a/markdown/__main__.py
+++ b/markdown/__main__.py
@@ -27,7 +27,7 @@ def parse_options(args=None, values=None):
     usage = """%prog [options] [INPUTFILE]
        (STDIN is assumed if no INPUTFILE is given)"""
     desc = "A Python implementation of John Gruber's Markdown. " \
-           "https://pythonhosted.org/Markdown/"
+           "https://python-markdown.github.io/"
     ver = "%%prog %s" % markdown.version
 
     parser = optparse.OptionParser(usage=usage, description=desc, version=ver)

--- a/markdown/extensions/abbr.py
+++ b/markdown/extensions/abbr.py
@@ -4,7 +4,7 @@ Abbreviation Extension for Python-Markdown
 
 This extension adds abbreviation handling to Python-Markdown.
 
-See <https://pythonhosted.org/Markdown/extensions/abbreviations.html>
+See <https://python-markdown.github.io/extensions/abbreviations>
 for documentation.
 
 Oringinal code Copyright 2007-2008 [Waylan Limberg](http://achinghead.com/) and

--- a/markdown/extensions/admonition.py
+++ b/markdown/extensions/admonition.py
@@ -6,7 +6,7 @@ Adds rST-style admonitions. Inspired by [rST][] feature with the same name.
 
 [rST]: http://docutils.sourceforge.net/docs/ref/rst/directives.html#specific-admonitions  # noqa
 
-See <https://pythonhosted.org/Markdown/extensions/admonition.html>
+See <https://python-markdown.github.io/extensions/admonition>
 for documentation.
 
 Original code Copyright [Tiago Serafim](http://www.tiagoserafim.com/).

--- a/markdown/extensions/attr_list.py
+++ b/markdown/extensions/attr_list.py
@@ -6,7 +6,7 @@ Adds attribute list syntax. Inspired by
 [maruku](http://maruku.rubyforge.org/proposal.html#attribute_lists)'s
 feature of the same name.
 
-See <https://pythonhosted.org/Markdown/extensions/attr_list.html>
+See <https://python-markdown.github.io/extensions/attr_list>
 for documentation.
 
 Original code Copyright 2011 [Waylan Limberg](http://achinghead.com/).

--- a/markdown/extensions/codehilite.py
+++ b/markdown/extensions/codehilite.py
@@ -4,7 +4,7 @@ CodeHilite Extension for Python-Markdown
 
 Adds code/syntax highlighting to standard Python-Markdown code blocks.
 
-See <https://pythonhosted.org/Markdown/extensions/code_hilite.html>
+See <https://python-markdown.github.io/extensions/code_hilite>
 for documentation.
 
 Original code Copyright 2006-2008 [Waylan Limberg](http://achinghead.com/).

--- a/markdown/extensions/def_list.py
+++ b/markdown/extensions/def_list.py
@@ -4,7 +4,7 @@ Definition List Extension for Python-Markdown
 
 Adds parsing of Definition Lists to Python-Markdown.
 
-See <https://pythonhosted.org/Markdown/extensions/definition_lists.html>
+See <https://python-markdown.github.io/extensions/definition_lists>
 for documentation.
 
 Original code Copyright 2008 [Waylan Limberg](http://achinghead.com)

--- a/markdown/extensions/extra.py
+++ b/markdown/extensions/extra.py
@@ -20,7 +20,7 @@ under a differant name. You could also edit the `extensions` global
 variable defined below, but be aware that such changes may be lost
 when you upgrade to any future version of Python-Markdown.
 
-See <https://pythonhosted.org/Markdown/extensions/extra.html>
+See <https://python-markdown.github.io/extensions/extra>
 for documentation.
 
 Copyright The Python Markdown Project

--- a/markdown/extensions/fenced_code.py
+++ b/markdown/extensions/fenced_code.py
@@ -4,7 +4,7 @@ Fenced Code Extension for Python Markdown
 
 This extension adds Fenced Code Blocks to Python-Markdown.
 
-See <https://pythonhosted.org/Markdown/extensions/fenced_code_blocks.html>
+See <https://python-markdown.github.io/extensions/fenced_code_blocks>
 for documentation.
 
 Original code Copyright 2007-2008 [Waylan Limberg](http://achinghead.com/).

--- a/markdown/extensions/footnotes.py
+++ b/markdown/extensions/footnotes.py
@@ -4,7 +4,7 @@ Footnotes Extension for Python-Markdown
 
 Adds footnote handling to Python-Markdown.
 
-See <https://pythonhosted.org/Markdown/extensions/footnotes.html>
+See <https://python-markdown.github.io/extensions/footnotes>
 for documentation.
 
 Copyright The Python Markdown Project

--- a/markdown/extensions/headerid.py
+++ b/markdown/extensions/headerid.py
@@ -4,7 +4,7 @@ HeaderID Extension for Python-Markdown
 
 Auto-generate id attributes for HTML headers.
 
-See <https://pythonhosted.org/Markdown/extensions/header_id.html>
+See <https://python-markdown.github.io/extensions/header_id>
 for documentation.
 
 Original code Copyright 2007-2011 [Waylan Limberg](http://achinghead.com/).

--- a/markdown/extensions/meta.py
+++ b/markdown/extensions/meta.py
@@ -4,7 +4,7 @@ Meta Data Extension for Python-Markdown
 
 This extension adds Meta Data handling to markdown.
 
-See <https://pythonhosted.org/Markdown/extensions/meta_data.html>
+See <https://python-markdown.github.io/extensions/meta_data>
 for documentation.
 
 Original code Copyright 2007-2008 [Waylan Limberg](http://achinghead.com).

--- a/markdown/extensions/nl2br.py
+++ b/markdown/extensions/nl2br.py
@@ -5,7 +5,7 @@ NL2BR Extension
 A Python-Markdown extension to treat newlines as hard breaks; like
 GitHub-flavored Markdown does.
 
-See <https://pythonhosted.org/Markdown/extensions/nl2br.html>
+See <https://python-markdown.github.io/extensions/nl2br>
 for documentation.
 
 Oringinal code Copyright 2011 [Brian Neal](http://deathofagremmie.com/)

--- a/markdown/extensions/sane_lists.py
+++ b/markdown/extensions/sane_lists.py
@@ -4,7 +4,7 @@ Sane List Extension for Python-Markdown
 
 Modify the behavior of Lists in Python-Markdown to act in a sane manor.
 
-See <https://pythonhosted.org/Markdown/extensions/sane_lists.html>
+See <https://python-markdown.github.io/extensions/sane_lists>
 for documentation.
 
 Original code Copyright 2011 [Waylan Limberg](http://achinghead.com)

--- a/markdown/extensions/smart_strong.py
+++ b/markdown/extensions/smart_strong.py
@@ -4,7 +4,7 @@ Smart_Strong Extension for Python-Markdown
 
 This extention adds smarter handling of double underscores within words.
 
-See <https://pythonhosted.org/Markdown/extensions/smart_strong.html>
+See <https://python-markdown.github.io/extensions/smart_strong>
 for documentation.
 
 Original code Copyright 2011 [Waylan Limberg](http://achinghead.com)

--- a/markdown/extensions/smarty.py
+++ b/markdown/extensions/smarty.py
@@ -6,7 +6,7 @@ Smarty extension for Python-Markdown
 Adds conversion of ASCII dashes, quotes and ellipses to their HTML
 entity equivalents.
 
-See <https://pythonhosted.org/Markdown/extensions/smarty.html>
+See <https://python-markdown.github.io/extensions/smarty>
 for documentation.
 
 Author: 2013, Dmitry Shachnev <mitya57@gmail.com>

--- a/markdown/extensions/superfences.py
+++ b/markdown/extensions/superfences.py
@@ -17,7 +17,7 @@ Fenced Code Extension for Python Markdown
 
 This extension adds Fenced Code Blocks to Python-Markdown.
 
-See <https://pythonhosted.org/Markdown/extensions/fenced_code_blocks.html>
+See <https://python-markdown.github.io/extensions/fenced_code_blocks>
 for documentation.
 
 Original code Copyright 2007-2008 [Waylan Limberg](http://achinghead.com/).

--- a/markdown/extensions/tables.py
+++ b/markdown/extensions/tables.py
@@ -4,7 +4,7 @@ Tables Extension for Python-Markdown
 
 Added parsing of tables to Python-Markdown.
 
-See <https://pythonhosted.org/Markdown/extensions/tables.html>
+See <https://python-markdown.github.io/extensions/tables>
 for documentation.
 
 Original code Copyright 2009 [Waylan Limberg](http://achinghead.com)

--- a/markdown/extensions/toc.py
+++ b/markdown/extensions/toc.py
@@ -2,7 +2,7 @@
 Table of Contents Extension for Python-Markdown
 ===============================================
 
-See <https://pythonhosted.org/Markdown/extensions/toc.html>
+See <https://python-markdown.github.io/extensions/toc>
 for documentation.
 
 Oringinal code Copyright 2008 [Jack Miller](http://codezen.org)

--- a/markdown/extensions/wikilinks.py
+++ b/markdown/extensions/wikilinks.py
@@ -4,7 +4,7 @@ WikiLinks Extension for Python-Markdown
 
 Converts [[WikiLinks]] to relative links.
 
-See <https://pythonhosted.org/Markdown/extensions/wikilinks.html>
+See <https://python-markdown.github.io/extensions/wikilinks>
 for documentation.
 
 Original code Copyright [Waylan Limberg](http://achinghead.com/).

--- a/sample.html
+++ b/sample.html
@@ -105,13 +105,13 @@ async_call('/path/to/api', function(json) {
 <p>The <a href="https://github.com/waylan/Python-Markdown">Python-Markdown Parser</a> provides support for several extensions.</p>
 <h4 id="extra-extensions">Extra Extensions</h4>
 <ul>
-<li><code>abbr</code> -- <a href="http://pythonhosted.org/Markdown/extensions/abbreviations.html">Abbreviations</a></li>
-<li><code>attr_list</code> -- <a href="http://pythonhosted.org/Markdown/extensions/attr_list.html">Attribute Lists</a></li>
-<li><code>def_list</code> -- <a href="http://pythonhosted.org/Markdown/extensions/definition_lists.html">Definition Lists</a></li>
-<li><code>fenced_code</code> -- <a href="http://pythonhosted.org/Markdown/extensions/fenced_code_blocks.html">Fenced Code Blocks</a></li>
-<li><code>footnotes</code> -- <a href="http://pythonhosted.org/Markdown/extensions/footnotes.html">Footnotes</a></li>
-<li><code>tables</code> -- <a href="http://pythonhosted.org/Markdown/extensions/tables.html">Tables</a></li>
-<li><code>smart_strong</code> -- <a href="http://pythonhosted.org/Markdown/extensions/smart_strong.html">Smart Strong</a></li>
+<li><code>abbr</code> -- <a href="https://python-markdown.github.io/extensions/abbreviations">Abbreviations</a></li>
+<li><code>attr_list</code> -- <a href="https://python-markdown.github.io/extensions/attr_list">Attribute Lists</a></li>
+<li><code>def_list</code> -- <a href="https://python-markdown.github.io/extensions/definition_lists">Definition Lists</a></li>
+<li><code>fenced_code</code> -- <a href="https://python-markdown.github.io/extensions/fenced_code_blocks">Fenced Code Blocks</a></li>
+<li><code>footnotes</code> -- <a href="https://python-markdown.github.io/extensions/footnotes">Footnotes</a></li>
+<li><code>tables</code> -- <a href="https://python-markdown.github.io/extensions/tables">Tables</a></li>
+<li><code>smart_strong</code> -- <a href="https://python-markdown.github.io/extensions/smart_strong">Smart Strong</a></li>
 </ul>
 <p>You can enable them all at once using the <code>extra</code> keyword.</p>
 <pre><code>extensions: [ 'extra' ]
@@ -129,15 +129,14 @@ your settings would look like this:</p>
 <p>There are also some extensions that are not included in Markdown Extra
 but come in the standard Python-Markdown library.</p>
 <ul>
-<li><code>code-hilite</code> -- <a href="http://pythonhosted.org/Markdown/extensions/code_hilite.html">CodeHilite</a></li>
-<li><code>html-tidy</code> -- <a href="http://pythonhosted.org/Markdown/extensions/html_tidy.html">HTML Tidy</a></li>
-<li><code>header-id</code> -- <a href="http://pythonhosted.org/Markdown/extensions/header_id.html">HeaderId</a></li>
-<li><code>meta_data</code> -- <a href="http://pythonhosted.org/Markdown/extensions/meta_data.html">Meta-Data</a></li>
-<li><code>nl2br</code> -- <a href="http://pythonhosted.org/Markdown/extensions/nl2br.html">New Line to Break</a></li>
-<li><code>rss</code> -- <a href="http://pythonhosted.org/Markdown/extensions/rss.html">RSS</a></li>
-<li><code>sane_lists</code> -- <a href="http://pythonhosted.org/Markdown/extensions/sane_lists.html">Sane Lists</a></li>
-<li><code>toc</code> -- <a href="http://pythonhosted.org/Markdown/extensions/toc.html">Table of Contents</a></li>
-<li><code>wikilinks</code> -- <a href="http://pythonhosted.org/Markdown/extensions/wikilinks.html">WikiLinks</a></li>
+<li><code>code-hilite</code> -- <a href="https://python-markdown.github.io/extensions/code_hilite">CodeHilite</a></li>
+<li><code>html-tidy</code> -- <a href="https://python-markdown.github.io/extensions/html_tidy">HTML Tidy</a></li>
+<li><code>header-id</code> -- <a href="https://python-markdown.github.io/extensions/header_id">HeaderId</a></li>
+<li><code>meta_data</code> -- <a href="https://python-markdown.github.io/extensions/meta_data">Meta-Data</a></li>
+<li><code>nl2br</code> -- <a href="https://python-markdown.github.io/extensions/nl2br">New Line to Break</a></li>
+<li><code>sane_lists</code> -- <a href="https://python-markdown.github.io/extensions/sane_lists">Sane Lists</a></li>
+<li><code>toc</code> -- <a href="https://python-markdown.github.io/extensions/toc">Table of Contents</a></li>
+<li><code>wikilinks</code> -- <a href="https://python-markdown.github.io/extensions/wikilinks">WikiLinks</a></li>
 </ul>
 <h4 id="3rd-party-extensions">3rd Party Extensions</h4>
 <p><em>Python-Markdown</em> is designed to be extended.
@@ -146,10 +145,10 @@ Just fork this repo and add your extensions inside the <code>.../Packages/Markdo
 <h4 id="default-extensions">Default Extensions</h4>
 <p>The default extensions are:</p>
 <ul>
-<li><code>footnotes</code> -- <a href="http://pythonhosted.org/Markdown/extensions/footnotes.html">Footnotes</a></li>
-<li><code>toc</code> -- <a href="http://pythonhosted.org/Markdown/extensions/toc.html">Table of Contents</a></li>
-<li><code>fenced_code</code> -- <a href="http://pythonhosted.org/Markdown/extensions/fenced_code_blocks.html">Fenced Code Blocks</a> </li>
-<li><code>tables</code> -- <a href="http://pythonhosted.org/Markdown/extensions/tables.html">Tables</a></li>
+<li><code>footnotes</code> -- <a href="https://python-markdown.github.io/extensions/footnotes">Footnotes</a></li>
+<li><code>toc</code> -- <a href="https://python-markdown.github.io/extensions/toc">Table of Contents</a></li>
+<li><code>fenced_code</code> -- <a href="https://python-markdown.github.io/extensions/fenced_code_blocks">Fenced Code Blocks</a> </li>
+<li><code>tables</code> -- <a href="https://python-markdown.github.io/extensions/tables">Tables</a></li>
 </ul>
 <p>Use the <code>default</code> keyword, to select them all.
 If you want all the defaults plus the <code>definition_lists</code> extension,

--- a/sample.md
+++ b/sample.md
@@ -149,13 +149,13 @@ The [Python-Markdown Parser][] provides support for several extensions.
 * `tables` -- [Tables][]
 * `smart_strong` -- [Smart Strong][]
 
-[Abbreviations]: http://pythonhosted.org/Markdown/extensions/abbreviations.html
-[Attribute Lists]: http://pythonhosted.org/Markdown/extensions/attr_list.html
-[Definition Lists]: http://pythonhosted.org/Markdown/extensions/definition_lists.html
-[Fenced Code Blocks]: http://pythonhosted.org/Markdown/extensions/fenced_code_blocks.html
-[Footnotes]: http://pythonhosted.org/Markdown/extensions/footnotes.html
-[Tables]: http://pythonhosted.org/Markdown/extensions/tables.html
-[Smart Strong]: http://pythonhosted.org/Markdown/extensions/smart_strong.html
+[Abbreviations]: https://python-markdown.github.io/extensions/abbreviations
+[Attribute Lists]: https://python-markdown.github.io/extensions/attr_list
+[Definition Lists]: https://python-markdown.github.io/extensions/definition_lists
+[Fenced Code Blocks]: https://python-markdown.github.io/extensions/fenced_code_blocks
+[Footnotes]: https://python-markdown.github.io/extensions/footnotes
+[Tables]: https://python-markdown.github.io/extensions/tables
+[Smart Strong]: https://python-markdown.github.io/extensions/smart_strong
 
 
 You can enable them all at once using the `extra` keyword.
@@ -183,22 +183,20 @@ but come in the standard Python-Markdown library.
 * `header-id` -- [HeaderId][]
 * `meta_data` -- [Meta-Data][]
 * `nl2br` -- [New Line to Break][]
-* `rss` -- [RSS][]
 * `sane_lists` -- [Sane Lists][]
 * `smarty` -- [Smarty][]
 * `toc` -- [Table of Contents][]
 * `wikilinks` -- [WikiLinks][]
 
-[CodeHilite]:  http://pythonhosted.org/Markdown/extensions/code_hilite.html
-[HTML Tidy]:  http://pythonhosted.org/Markdown/extensions/html_tidy.html
-[HeaderId]:  http://pythonhosted.org/Markdown/extensions/header_id.html
-[Meta-Data]:  http://pythonhosted.org/Markdown/extensions/meta_data.html
-[New Line to Break]:  http://pythonhosted.org/Markdown/extensions/nl2br.html
-[RSS]:  http://pythonhosted.org/Markdown/extensions/rss.html
-[Sane Lists]:  http://pythonhosted.org/Markdown/extensions/sane_lists.html
-[Table of Contents]:  http://pythonhosted.org/Markdown/extensions/toc.html
-[WikiLinks]:  http://pythonhosted.org/Markdown/extensions/wikilinks.html
-[Smarty]: https://pythonhosted.org/Markdown/extensions/smarty.html
+[CodeHilite]:  https://python-markdown.github.io/extensions/code_hilite
+[HTML Tidy]:  https://python-markdown.github.io/extensions/html_tidy
+[HeaderId]:  https://python-markdown.github.io/extensions/header_id
+[Meta-Data]:  https://python-markdown.github.io/extensions/meta_data
+[New Line to Break]:  https://python-markdown.github.io/extensions/nl2br
+[Sane Lists]:  https://python-markdown.github.io/extensions/sane_lists
+[Table of Contents]:  https://python-markdown.github.io/extensions/toc
+[WikiLinks]:  https://python-markdown.github.io/extensions/wikilinks
+[Smarty]: https://python-markdown.github.io/extensions/smarty
 
 #### 3rd Party Extensions
 


### PR DESCRIPTION
- Updated links to python-markdown
- Removed reference to the RSS extension which was removed in v2.3 (https://python-markdown.github.io/change_log/release-2.3/#backwards-incompatible-changes)