### PR TITLE
Fix 404 link to LiveReload from #414

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ The code is available at github [project][home] under [MIT license][4].
  [4]: http://revolunet.mit-license.org
  [5]: https://developer.github.com/v3/markdown/
  [6]: https://help.github.com/articles/github-flavored-markdown/
- [7]: https://github.com/Grafikart/ST3-LiveReload
+ [7]: https://packagecontrol.io/packages/LiveReload
  [8]: https://github.com/revolunet/sublimetext-markdown-preview/issues/27#issuecomment-11772098
  [9]: https://github.com/revolunet/sublimetext-markdown-preview/issues/78#issuecomment-15644727
  [10]: https://github.com/waylan/Python-Markdown


### PR DESCRIPTION
Fix issue #414  404 link to LiveReload on https://github.com/revolunet/sublimetext-markdown-preview/issues/414#issuecomment-373416014