### PR TITLE
clarify where to put key bindings as of Sublime 3.0 (build 3143)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Sublime Text 2/3 Markdown Previews
 =================================
 
-Preview and build your markdown files quickly in your web browser from sublime text 2/3. 
+Preview and build your markdown files quickly in your web browser from sublime text 2/3.
 
 You can use builtin [python-markdown][10] parser or use the [github markdown API][5] for the conversion.
 
@@ -52,9 +52,21 @@ When referring to settings, we are referring to the settings found at `Preferenc
     - Markdown Preview: Export HTML in Sublime Text
     - Markdown Preview: Copy to Clipboard
     - Markdown Preview: Open Markdown Cheat sheet
-        ![Usage Demo](sublimetext-markdown-preview.gif)
- - or bind some key in your user key binding, using a line like this one:
-   `{ "keys": ["alt+m"], "command": "markdown_preview", "args": {"target": "browser", "parser":"markdown"} },` for a specific parser and target or `{ "keys": ["alt+m"], "command": "markdown_preview_select", "args": {"target": "browser"} },` to bring up the quick panel to select enabled parsers for a given target.
+
+      ![Usage Demo](sublimetext-markdown-preview.gif)
+
+ - or bind some key in your user key binding, go to `Preferences --> Keybindings` then add to the User map:
+
+ for a specific parser and target:
+
+   ```
+   { "keys": ["alt+m"], "command": "markdown_preview", "args": {"target": "browser", "parser":"markdown"} },
+   ```
+    to bring up the quick panel to select enabled parsers for a given target:
+
+   ```
+   { "keys": ["alt+m"], "command": "markdown_preview_select", "args": {"target": "browser"} },
+   ```
 
 If you want to control which browser the preview is opened in, you can edit the `browser` option in the settings file:
 


### PR DESCRIPTION
update README; clarify where to put key bindings as of Sublime 3.0 (build 3143)

https://github.com/revolunet/sublimetext-markdown-preview/issues/399